### PR TITLE
feat: add global metrics tracking and dashboard

### DIFF
--- a/src/durable-objects/MetricsDO.ts
+++ b/src/durable-objects/MetricsDO.ts
@@ -1,0 +1,547 @@
+/**
+ * MetricsDO - Global Metrics Tracking Durable Object
+ *
+ * Tracks aggregate metrics across all payers for dashboard and analytics.
+ * Unlike UsageDO (per-payer), this provides a global view.
+ *
+ * Enhanced metrics include:
+ * - Error rates & types
+ * - Response sizes
+ * - Geographic distribution (CF datacenter)
+ */
+
+import { DurableObject } from "cloudflare:workers";
+import type { Env, TokenType, PricingTier } from "../types";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface MetricsRecord {
+  requestId: string;
+  endpoint: string;
+  category: string;
+  method: string;
+  statusCode: number;
+  isSuccess: boolean;
+  errorType?: string;
+  pricingType: "fixed" | "dynamic";
+  tier?: PricingTier;
+  amountCharged: number; // microSTX equivalent
+  token: TokenType;
+  durationMs: number;
+  responseBytes: number;
+  colo: string; // CF datacenter code (e.g., "SJC", "AMS")
+  payerAddress?: string;
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+export interface EndpointStats {
+  endpoint: string;
+  category: string;
+  totalCalls: number;
+  successfulCalls: number;
+  errorCalls: number;
+  avgLatencyMs: number;
+  totalBytes: number;
+  earningsSTX: number;
+  earningsSBTC: number;
+  earningsUSDCx: number;
+  created: string;
+  lastCall: string;
+}
+
+export interface DailyStatsRow {
+  date: string;
+  totalCalls: number;
+  successfulCalls: number;
+  errorCalls: number;
+  earningsSTX: number;
+}
+
+export interface ColoStats {
+  colo: string;
+  totalCalls: number;
+  avgLatencyMs: number;
+}
+
+export interface ErrorStats {
+  errorType: string;
+  count: number;
+  lastOccurred: string;
+}
+
+// =============================================================================
+// MetricsDO Implementation
+// =============================================================================
+
+export class MetricsDO extends DurableObject<Env> {
+  private sql: SqlStorage;
+
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    this.sql = ctx.storage.sql;
+
+    ctx.blockConcurrencyWhile(async () => {
+      this.initSchema();
+    });
+  }
+
+  private initSchema(): void {
+    this.sql.exec(`
+      -- Per-request metrics log (for detailed queries, pruned after 30 days)
+      CREATE TABLE IF NOT EXISTS metrics (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        request_id TEXT UNIQUE,
+        endpoint TEXT NOT NULL,
+        category TEXT NOT NULL,
+        method TEXT NOT NULL,
+        status_code INTEGER NOT NULL,
+        is_success INTEGER NOT NULL,
+        error_type TEXT,
+        pricing_type TEXT NOT NULL,
+        tier TEXT,
+        amount_charged INTEGER NOT NULL,
+        token TEXT NOT NULL,
+        duration_ms INTEGER NOT NULL,
+        response_bytes INTEGER NOT NULL,
+        colo TEXT NOT NULL,
+        payer_address TEXT,
+        model TEXT,
+        input_tokens INTEGER,
+        output_tokens INTEGER,
+        timestamp INTEGER NOT NULL
+      );
+
+      -- Aggregate endpoint stats (running totals)
+      CREATE TABLE IF NOT EXISTS endpoint_stats (
+        endpoint TEXT PRIMARY KEY,
+        category TEXT NOT NULL,
+        total_calls INTEGER DEFAULT 0,
+        successful_calls INTEGER DEFAULT 0,
+        error_calls INTEGER DEFAULT 0,
+        latency_sum INTEGER DEFAULT 0,
+        total_bytes INTEGER DEFAULT 0,
+        earnings_stx INTEGER DEFAULT 0,
+        earnings_sbtc INTEGER DEFAULT 0,
+        earnings_usdcx INTEGER DEFAULT 0,
+        created TEXT NOT NULL,
+        last_call TEXT NOT NULL
+      );
+
+      -- Daily aggregates
+      CREATE TABLE IF NOT EXISTS daily_stats (
+        date TEXT PRIMARY KEY,
+        total_calls INTEGER DEFAULT 0,
+        successful_calls INTEGER DEFAULT 0,
+        error_calls INTEGER DEFAULT 0,
+        earnings_stx INTEGER DEFAULT 0,
+        earnings_sbtc INTEGER DEFAULT 0,
+        earnings_usdcx INTEGER DEFAULT 0
+      );
+
+      -- Geographic distribution
+      CREATE TABLE IF NOT EXISTS colo_stats (
+        colo TEXT PRIMARY KEY,
+        total_calls INTEGER DEFAULT 0,
+        latency_sum INTEGER DEFAULT 0,
+        last_seen TEXT NOT NULL
+      );
+
+      -- Error tracking
+      CREATE TABLE IF NOT EXISTS error_stats (
+        error_type TEXT PRIMARY KEY,
+        count INTEGER DEFAULT 0,
+        last_occurred TEXT NOT NULL
+      );
+
+      -- Indexes
+      CREATE INDEX IF NOT EXISTS idx_metrics_timestamp ON metrics(timestamp);
+      CREATE INDEX IF NOT EXISTS idx_metrics_endpoint ON metrics(endpoint);
+      CREATE INDEX IF NOT EXISTS idx_metrics_category ON metrics(category);
+      CREATE INDEX IF NOT EXISTS idx_metrics_colo ON metrics(colo);
+      CREATE INDEX IF NOT EXISTS idx_daily_stats_date ON daily_stats(date);
+    `);
+  }
+
+  // ===========================================================================
+  // Record Metrics
+  // ===========================================================================
+
+  async recordMetrics(record: MetricsRecord): Promise<void> {
+    const now = new Date();
+    const timestamp = now.getTime();
+    const today = now.toISOString().split("T")[0];
+    const nowIso = now.toISOString();
+
+    // Calculate earnings based on token type (convert to micro units)
+    const earningsStx = record.token === "STX" ? record.amountCharged : 0;
+    const earningsSbtc = record.token === "sBTC" ? record.amountCharged : 0;
+    const earningsUsdcx = record.token === "USDCx" ? record.amountCharged : 0;
+
+    // Insert detailed metrics record
+    this.sql.exec(
+      `INSERT OR IGNORE INTO metrics (
+        request_id, endpoint, category, method, status_code, is_success,
+        error_type, pricing_type, tier, amount_charged, token, duration_ms,
+        response_bytes, colo, payer_address, model, input_tokens, output_tokens, timestamp
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      record.requestId,
+      record.endpoint,
+      record.category,
+      record.method,
+      record.statusCode,
+      record.isSuccess ? 1 : 0,
+      record.errorType || null,
+      record.pricingType,
+      record.tier || null,
+      record.amountCharged,
+      record.token,
+      record.durationMs,
+      record.responseBytes,
+      record.colo,
+      record.payerAddress || null,
+      record.model || null,
+      record.inputTokens || null,
+      record.outputTokens || null,
+      timestamp
+    );
+
+    // Update endpoint aggregate stats
+    this.sql.exec(
+      `INSERT INTO endpoint_stats (
+        endpoint, category, total_calls, successful_calls, error_calls,
+        latency_sum, total_bytes, earnings_stx, earnings_sbtc, earnings_usdcx,
+        created, last_call
+      ) VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(endpoint) DO UPDATE SET
+        total_calls = total_calls + 1,
+        successful_calls = successful_calls + excluded.successful_calls,
+        error_calls = error_calls + excluded.error_calls,
+        latency_sum = latency_sum + excluded.latency_sum,
+        total_bytes = total_bytes + excluded.total_bytes,
+        earnings_stx = earnings_stx + excluded.earnings_stx,
+        earnings_sbtc = earnings_sbtc + excluded.earnings_sbtc,
+        earnings_usdcx = earnings_usdcx + excluded.earnings_usdcx,
+        last_call = excluded.last_call`,
+      record.endpoint,
+      record.category,
+      record.isSuccess ? 1 : 0,
+      record.isSuccess ? 0 : 1,
+      record.durationMs,
+      record.responseBytes,
+      earningsStx,
+      earningsSbtc,
+      earningsUsdcx,
+      nowIso,
+      nowIso
+    );
+
+    // Update daily stats
+    this.sql.exec(
+      `INSERT INTO daily_stats (
+        date, total_calls, successful_calls, error_calls,
+        earnings_stx, earnings_sbtc, earnings_usdcx
+      ) VALUES (?, 1, ?, ?, ?, ?, ?)
+      ON CONFLICT(date) DO UPDATE SET
+        total_calls = total_calls + 1,
+        successful_calls = successful_calls + excluded.successful_calls,
+        error_calls = error_calls + excluded.error_calls,
+        earnings_stx = earnings_stx + excluded.earnings_stx,
+        earnings_sbtc = earnings_sbtc + excluded.earnings_sbtc,
+        earnings_usdcx = earnings_usdcx + excluded.earnings_usdcx`,
+      today,
+      record.isSuccess ? 1 : 0,
+      record.isSuccess ? 0 : 1,
+      earningsStx,
+      earningsSbtc,
+      earningsUsdcx
+    );
+
+    // Update colo stats
+    this.sql.exec(
+      `INSERT INTO colo_stats (colo, total_calls, latency_sum, last_seen)
+       VALUES (?, 1, ?, ?)
+       ON CONFLICT(colo) DO UPDATE SET
+         total_calls = total_calls + 1,
+         latency_sum = latency_sum + excluded.latency_sum,
+         last_seen = excluded.last_seen`,
+      record.colo,
+      record.durationMs,
+      nowIso
+    );
+
+    // Update error stats if this was an error
+    if (!record.isSuccess && record.errorType) {
+      this.sql.exec(
+        `INSERT INTO error_stats (error_type, count, last_occurred)
+         VALUES (?, 1, ?)
+         ON CONFLICT(error_type) DO UPDATE SET
+           count = count + 1,
+           last_occurred = excluded.last_occurred`,
+        record.errorType,
+        nowIso
+      );
+    }
+
+    // Prune old detailed metrics (keep 30 days)
+    const cutoffTs = timestamp - 30 * 24 * 60 * 60 * 1000;
+    this.sql.exec("DELETE FROM metrics WHERE timestamp < ?", cutoffTs);
+
+    // Prune old daily stats (keep 90 days)
+    const cutoffDate = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .split("T")[0];
+    this.sql.exec("DELETE FROM daily_stats WHERE date < ?", cutoffDate);
+  }
+
+  // ===========================================================================
+  // Dashboard Queries
+  // ===========================================================================
+
+  /**
+   * Get all endpoint stats for dashboard
+   */
+  async getEndpointStats(): Promise<EndpointStats[]> {
+    const results = this.sql
+      .exec(
+        `SELECT endpoint, category, total_calls, successful_calls, error_calls,
+                latency_sum, total_bytes, earnings_stx, earnings_sbtc, earnings_usdcx,
+                created, last_call
+         FROM endpoint_stats
+         ORDER BY total_calls DESC`
+      )
+      .toArray();
+
+    return results.map((row) => ({
+      endpoint: row.endpoint as string,
+      category: row.category as string,
+      totalCalls: row.total_calls as number,
+      successfulCalls: row.successful_calls as number,
+      errorCalls: row.error_calls as number,
+      avgLatencyMs:
+        (row.total_calls as number) > 0
+          ? Math.round((row.latency_sum as number) / (row.total_calls as number))
+          : 0,
+      totalBytes: row.total_bytes as number,
+      earningsSTX: row.earnings_stx as number,
+      earningsSBTC: row.earnings_sbtc as number,
+      earningsUSDCx: row.earnings_usdcx as number,
+      created: row.created as string,
+      lastCall: row.last_call as string,
+    }));
+  }
+
+  /**
+   * Get daily stats for charts
+   */
+  async getDailyStats(days: number = 7): Promise<DailyStatsRow[]> {
+    const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .split("T")[0];
+
+    const results = this.sql
+      .exec(
+        `SELECT date, total_calls, successful_calls, error_calls, earnings_stx
+         FROM daily_stats
+         WHERE date >= ?
+         ORDER BY date ASC`,
+        cutoff
+      )
+      .toArray();
+
+    // Fill in missing days with zeros
+    const statsMap = new Map<string, DailyStatsRow>();
+    for (const row of results) {
+      statsMap.set(row.date as string, {
+        date: row.date as string,
+        totalCalls: row.total_calls as number,
+        successfulCalls: row.successful_calls as number,
+        errorCalls: row.error_calls as number,
+        earningsSTX: row.earnings_stx as number,
+      });
+    }
+
+    const allDays: DailyStatsRow[] = [];
+    for (let i = days - 1; i >= 0; i--) {
+      const date = new Date(Date.now() - i * 24 * 60 * 60 * 1000)
+        .toISOString()
+        .split("T")[0];
+      allDays.push(
+        statsMap.get(date) || {
+          date,
+          totalCalls: 0,
+          successfulCalls: 0,
+          errorCalls: 0,
+          earningsSTX: 0,
+        }
+      );
+    }
+
+    return allDays;
+  }
+
+  /**
+   * Get geographic distribution
+   */
+  async getColoStats(): Promise<ColoStats[]> {
+    const results = this.sql
+      .exec(
+        `SELECT colo, total_calls, latency_sum
+         FROM colo_stats
+         ORDER BY total_calls DESC
+         LIMIT 20`
+      )
+      .toArray();
+
+    return results.map((row) => ({
+      colo: row.colo as string,
+      totalCalls: row.total_calls as number,
+      avgLatencyMs:
+        (row.total_calls as number) > 0
+          ? Math.round((row.latency_sum as number) / (row.total_calls as number))
+          : 0,
+    }));
+  }
+
+  /**
+   * Get error statistics
+   */
+  async getErrorStats(): Promise<ErrorStats[]> {
+    const results = this.sql
+      .exec(
+        `SELECT error_type, count, last_occurred
+         FROM error_stats
+         ORDER BY count DESC
+         LIMIT 20`
+      )
+      .toArray();
+
+    return results.map((row) => ({
+      errorType: row.error_type as string,
+      count: row.count as number,
+      lastOccurred: row.last_occurred as string,
+    }));
+  }
+
+  /**
+   * Get summary totals for dashboard header
+   */
+  async getSummary(): Promise<{
+    totalEndpoints: number;
+    totalCalls: number;
+    totalSuccessful: number;
+    totalErrors: number;
+    avgSuccessRate: number;
+    earningsSTX: number;
+    earningsSBTC: number;
+    earningsUSDCx: number;
+    uniqueColos: number;
+  }> {
+    const endpointCount = this.sql
+      .exec("SELECT COUNT(*) as cnt FROM endpoint_stats")
+      .toArray()[0]?.cnt as number || 0;
+
+    const totals = this.sql
+      .exec(
+        `SELECT
+          COALESCE(SUM(total_calls), 0) as total_calls,
+          COALESCE(SUM(successful_calls), 0) as successful,
+          COALESCE(SUM(error_calls), 0) as errors,
+          COALESCE(SUM(earnings_stx), 0) as stx,
+          COALESCE(SUM(earnings_sbtc), 0) as sbtc,
+          COALESCE(SUM(earnings_usdcx), 0) as usdcx
+         FROM endpoint_stats`
+      )
+      .toArray()[0];
+
+    const coloCount = this.sql
+      .exec("SELECT COUNT(*) as cnt FROM colo_stats")
+      .toArray()[0]?.cnt as number || 0;
+
+    const totalCalls = (totals?.total_calls as number) || 0;
+    const successful = (totals?.successful as number) || 0;
+
+    return {
+      totalEndpoints: endpointCount,
+      totalCalls,
+      totalSuccessful: successful,
+      totalErrors: (totals?.errors as number) || 0,
+      avgSuccessRate: totalCalls > 0 ? (successful / totalCalls) * 100 : 0,
+      earningsSTX: (totals?.stx as number) || 0,
+      earningsSBTC: (totals?.sbtc as number) || 0,
+      earningsUSDCx: (totals?.usdcx as number) || 0,
+      uniqueColos: coloCount,
+    };
+  }
+
+  /**
+   * Get recent requests (for live feed)
+   */
+  async getRecentRequests(limit: number = 20): Promise<
+    Array<{
+      requestId: string;
+      endpoint: string;
+      statusCode: number;
+      durationMs: number;
+      colo: string;
+      timestamp: string;
+    }>
+  > {
+    const results = this.sql
+      .exec(
+        `SELECT request_id, endpoint, status_code, duration_ms, colo, timestamp
+         FROM metrics
+         ORDER BY timestamp DESC
+         LIMIT ?`,
+        limit
+      )
+      .toArray();
+
+    return results.map((row) => ({
+      requestId: row.request_id as string,
+      endpoint: row.endpoint as string,
+      statusCode: row.status_code as number,
+      durationMs: row.duration_ms as number,
+      colo: row.colo as string,
+      timestamp: new Date(row.timestamp as number).toISOString(),
+    }));
+  }
+
+  /**
+   * Get model usage stats (for LLM endpoints)
+   */
+  async getModelStats(): Promise<
+    Array<{
+      model: string;
+      totalCalls: number;
+      totalInputTokens: number;
+      totalOutputTokens: number;
+      totalEarningsSTX: number;
+    }>
+  > {
+    const results = this.sql
+      .exec(
+        `SELECT model,
+                COUNT(*) as total_calls,
+                COALESCE(SUM(input_tokens), 0) as input_tokens,
+                COALESCE(SUM(output_tokens), 0) as output_tokens,
+                COALESCE(SUM(CASE WHEN token = 'STX' THEN amount_charged ELSE 0 END), 0) as earnings
+         FROM metrics
+         WHERE model IS NOT NULL
+         GROUP BY model
+         ORDER BY total_calls DESC`
+      )
+      .toArray();
+
+    return results.map((row) => ({
+      model: row.model as string,
+      totalCalls: row.total_calls as number,
+      totalInputTokens: row.input_tokens as number,
+      totalOutputTokens: row.output_tokens as number,
+      totalEarningsSTX: row.earnings as number,
+    }));
+  }
+}

--- a/src/endpoints/dashboard.ts
+++ b/src/endpoints/dashboard.ts
@@ -1,0 +1,763 @@
+/**
+ * Dashboard Endpoint
+ *
+ * HTML dashboard showing API metrics, usage stats, and analytics.
+ * Free endpoint (no payment required).
+ */
+
+import { OpenAPIRoute } from "chanfana";
+import type { AppContext } from "../types";
+
+// =============================================================================
+// Dashboard Endpoint
+// =============================================================================
+
+export class Dashboard extends OpenAPIRoute {
+  schema = {
+    tags: ["Info"],
+    summary: "View API metrics dashboard (free)",
+    responses: {
+      "200": {
+        description: "HTML dashboard",
+        content: {
+          "text/html": {
+            schema: { type: "string" as const },
+          },
+        },
+      },
+    },
+  };
+
+  async handle(c: AppContext) {
+    let dashboardData: DashboardData;
+
+    try {
+      const id = c.env.METRICS_DO.idFromName("global-metrics");
+      const metricsDO = c.env.METRICS_DO.get(id);
+
+      const [summary, endpoints, daily, colos, errors, modelStats] =
+        await Promise.all([
+          metricsDO.getSummary(),
+          metricsDO.getEndpointStats(),
+          metricsDO.getDailyStats(7),
+          metricsDO.getColoStats(),
+          metricsDO.getErrorStats(),
+          metricsDO.getModelStats(),
+        ]);
+
+      dashboardData = {
+        summary,
+        endpoints,
+        daily,
+        colos,
+        errors,
+        modelStats,
+      };
+    } catch (error) {
+      console.error("Failed to load dashboard data:", error);
+      dashboardData = {
+        summary: {
+          totalEndpoints: 0,
+          totalCalls: 0,
+          totalSuccessful: 0,
+          totalErrors: 0,
+          avgSuccessRate: 0,
+          earningsSTX: 0,
+          earningsSBTC: 0,
+          earningsUSDCx: 0,
+          uniqueColos: 0,
+        },
+        endpoints: [],
+        daily: [],
+        colos: [],
+        errors: [],
+        modelStats: [],
+      };
+    }
+
+    const html = generateDashboardHTML(dashboardData, c.env.ENVIRONMENT);
+    return c.html(html);
+  }
+}
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface DashboardData {
+  summary: {
+    totalEndpoints: number;
+    totalCalls: number;
+    totalSuccessful: number;
+    totalErrors: number;
+    avgSuccessRate: number;
+    earningsSTX: number;
+    earningsSBTC: number;
+    earningsUSDCx: number;
+    uniqueColos: number;
+  };
+  endpoints: Array<{
+    endpoint: string;
+    category: string;
+    totalCalls: number;
+    successfulCalls: number;
+    errorCalls: number;
+    avgLatencyMs: number;
+    totalBytes: number;
+    earningsSTX: number;
+    earningsSBTC: number;
+    earningsUSDCx: number;
+    created: string;
+    lastCall: string;
+  }>;
+  daily: Array<{
+    date: string;
+    totalCalls: number;
+    successfulCalls: number;
+    errorCalls: number;
+    earningsSTX: number;
+  }>;
+  colos: Array<{
+    colo: string;
+    totalCalls: number;
+    avgLatencyMs: number;
+  }>;
+  errors: Array<{
+    errorType: string;
+    count: number;
+    lastOccurred: string;
+  }>;
+  modelStats: Array<{
+    model: string;
+    totalCalls: number;
+    totalInputTokens: number;
+    totalOutputTokens: number;
+    totalEarningsSTX: number;
+  }>;
+}
+
+// =============================================================================
+// HTML Generation
+// =============================================================================
+
+function formatSTX(microSTX: number): string {
+  return (microSTX / 1_000_000).toFixed(6);
+}
+
+function formatSBTC(microSats: number): string {
+  // Display as sats
+  return Math.round(microSats).toLocaleString();
+}
+
+function formatUSDCx(microUSD: number): string {
+  return (microUSD / 1_000_000).toFixed(2);
+}
+
+function getCategoryClass(category: string): string {
+  const classes: Record<string, string> = {
+    inference: "cat-inference",
+    stacks: "cat-stacks",
+    hashing: "cat-hashing",
+    storage: "cat-storage",
+  };
+  return classes[category.toLowerCase()] || "cat-other";
+}
+
+function generateDashboardHTML(data: DashboardData, environment: string): string {
+  const { summary, endpoints, daily, colos, errors, modelStats } = data;
+
+  // Sort endpoints by total calls descending
+  const sortedEndpoints = [...endpoints].sort((a, b) => b.totalCalls - a.totalCalls);
+
+  // Calculate max for daily chart
+  const maxDailyCalls = Math.max(...daily.map((d) => d.totalCalls), 1);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>x402 API Dashboard</title>
+  <link rel="preconnect" href="https://rsms.me/">
+  <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
+  <style>
+    :root {
+      --bg-primary: #09090b;
+      --bg-card: #0f0f12;
+      --bg-hover: #18181b;
+      --border: rgba(255,255,255,0.06);
+      --border-hover: rgba(255,255,255,0.1);
+      --text-primary: #fafafa;
+      --text-secondary: #a1a1aa;
+      --text-muted: #71717a;
+      --accent: #f7931a;
+      --accent-dim: rgba(247, 147, 26, 0.12);
+      --success: #22c55e;
+      --error: #ef4444;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+      background: var(--bg-primary);
+      color: var(--text-primary);
+      min-height: 100vh;
+      line-height: 1.5;
+      -webkit-font-smoothing: antialiased;
+    }
+    .container { max-width: 1600px; margin: 0 auto; padding: 24px; }
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 32px;
+    }
+    h1 {
+      font-size: 32px;
+      font-weight: 700;
+      color: var(--text-primary);
+    }
+    h1 .accent { color: var(--accent); }
+    .env-badge {
+      background: ${environment === "production" ? "#166534" : "#1e3a5f"};
+      color: ${environment === "production" ? "#4ade80" : "#60a5fa"};
+      padding: 6px 12px;
+      border-radius: 6px;
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+    }
+    .subtitle { color: var(--text-muted); margin-bottom: 32px; font-size: 16px; }
+    .section-nav {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 32px;
+      flex-wrap: wrap;
+    }
+    .section-nav a {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      color: var(--text-secondary);
+      padding: 10px 18px;
+      border-radius: 10px;
+      text-decoration: none;
+      font-size: 13px;
+      font-weight: 500;
+      transition: all 0.2s ease;
+    }
+    .section-nav a:hover {
+      background: var(--bg-hover);
+      border-color: var(--border-hover);
+      color: var(--text-primary);
+    }
+    .summary {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 16px;
+      margin-bottom: 32px;
+    }
+    .card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 20px;
+      transition: all 0.2s ease;
+    }
+    .card:hover {
+      border-color: var(--border-hover);
+      transform: translateY(-2px);
+    }
+    .card h3 {
+      color: var(--text-muted);
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 8px;
+      font-weight: 500;
+    }
+    .card .value {
+      font-size: 28px;
+      font-weight: 700;
+      color: var(--text-primary);
+      letter-spacing: -0.02em;
+    }
+    .card .value.stx { color: #06b6d4; }
+    .card .value.sbtc { color: var(--accent); }
+    .card .value.usdcx { color: #3b82f6; }
+    .card .value.success { color: var(--success); }
+    .card .value.error { color: var(--error); }
+    .section-title {
+      font-size: 18px;
+      font-weight: 600;
+      margin-bottom: 16px;
+      margin-top: 32px;
+      color: #fff;
+      scroll-margin-top: 24px;
+    }
+    .grid-2 {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+      gap: 24px;
+    }
+    .chart-container {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 24px;
+    }
+    .chart-title {
+      font-size: 14px;
+      font-weight: 600;
+      margin-bottom: 16px;
+      color: var(--text-secondary);
+    }
+    .bar-chart {
+      display: flex;
+      align-items: flex-end;
+      gap: 8px;
+      height: 140px;
+    }
+    .bar-day {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      height: 100%;
+      justify-content: flex-end;
+    }
+    .bar {
+      width: 100%;
+      background: linear-gradient(180deg, var(--accent) 0%, #c2410c 100%);
+      border-radius: 4px 4px 0 0;
+      min-height: 4px;
+      transition: height 0.3s;
+    }
+    .bar.errors {
+      background: linear-gradient(180deg, var(--error) 0%, #991b1b 100%);
+      margin-top: 2px;
+    }
+    .bar-label { font-size: 11px; color: #71717a; }
+    .bar-value { font-size: 11px; color: #a1a1aa; font-weight: 500; }
+    .colo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+      gap: 8px;
+    }
+    .colo-item {
+      background: #27272a;
+      border-radius: 8px;
+      padding: 10px;
+      text-align: center;
+    }
+    .colo-item .colo-code {
+      font-size: 14px;
+      font-weight: 700;
+      color: #fff;
+      font-family: 'SF Mono', Monaco, monospace;
+    }
+    .colo-item .colo-count {
+      font-size: 11px;
+      color: #a1a1aa;
+      margin-top: 2px;
+    }
+    .colo-item .colo-latency {
+      font-size: 10px;
+      color: #71717a;
+    }
+    .error-list {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .error-item {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: #27272a;
+      border-radius: 8px;
+      padding: 10px 14px;
+    }
+    .error-item .error-type {
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--error);
+    }
+    .error-item .error-count {
+      font-size: 12px;
+      color: #a1a1aa;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+    th {
+      text-align: left;
+      padding: 12px 16px;
+      background: #18181b;
+      color: #71717a;
+      font-weight: 500;
+      text-transform: uppercase;
+      font-size: 11px;
+      letter-spacing: 0.5px;
+      border-bottom: 1px solid #27272a;
+      position: sticky;
+      top: 0;
+      cursor: pointer;
+      user-select: none;
+      transition: color 0.15s;
+    }
+    th:hover { color: #a1a1aa; }
+    th .sort-icon {
+      display: inline-block;
+      margin-left: 4px;
+      opacity: 0.3;
+    }
+    th.sorted .sort-icon { opacity: 1; color: var(--accent); }
+    th.sorted { color: var(--accent); }
+    td {
+      padding: 12px 16px;
+      border-bottom: 1px solid #27272a;
+      vertical-align: middle;
+    }
+    tr:hover { background: #1f1f23; }
+    code {
+      font-family: 'SF Mono', Monaco, monospace;
+      font-size: 12px;
+      background: #27272a;
+      padding: 4px 8px;
+      border-radius: 4px;
+    }
+    .success-high { color: #4ade80; }
+    .success-med { color: #fbbf24; }
+    .success-low { color: #f87171; }
+    .cat-inference { color: #a855f7; }
+    .cat-stacks { color: var(--accent); }
+    .cat-hashing { color: #06b6d4; }
+    .cat-storage { color: #3b82f6; }
+    .cat-other { color: #71717a; }
+    .table-container {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      overflow: hidden;
+    }
+    .table-scroll {
+      max-height: 500px;
+      overflow-y: auto;
+    }
+    .model-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 12px;
+    }
+    .model-card {
+      background: #27272a;
+      border-radius: 8px;
+      padding: 14px;
+    }
+    .model-name {
+      font-size: 13px;
+      font-weight: 600;
+      color: #fff;
+      margin-bottom: 8px;
+      word-break: break-all;
+    }
+    .model-stats {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 8px;
+      font-size: 11px;
+    }
+    .model-stat {
+      display: flex;
+      flex-direction: column;
+    }
+    .model-stat .stat-label { color: #71717a; }
+    .model-stat .stat-value { color: #a1a1aa; font-weight: 500; }
+    .footer {
+      margin-top: 48px;
+      padding-top: 24px;
+      border-top: 1px solid var(--border);
+      text-align: center;
+      color: var(--text-muted);
+      font-size: 13px;
+    }
+    .footer a { color: var(--accent); text-decoration: none; }
+    .footer a:hover { opacity: 0.8; }
+
+    @media (max-width: 600px) {
+      .container { padding: 16px; }
+      .header { flex-direction: column; gap: 12px; align-items: flex-start; }
+      .summary { grid-template-columns: repeat(2, 1fr); gap: 10px; }
+      .card { padding: 14px; }
+      .card .value { font-size: 20px; }
+      .grid-2 { grid-template-columns: 1fr; }
+      .section-nav { gap: 6px; }
+      .section-nav a { padding: 8px 12px; font-size: 12px; }
+      table { font-size: 11px; }
+      th, td { padding: 8px 10px; }
+      code { font-size: 10px; padding: 2px 4px; }
+    }
+
+    @media (max-width: 768px) {
+      th:nth-child(6), td:nth-child(6),
+      th:nth-child(7), td:nth-child(7),
+      th:nth-child(9), td:nth-child(9) { display: none; }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <div>
+        <h1><span class="accent">x402</span> Dashboard</h1>
+        <p class="subtitle">Real-time metrics for pay-per-use API on Stacks</p>
+      </div>
+      <span class="env-badge">${environment}</span>
+    </div>
+
+    <nav class="section-nav">
+      <a href="#summary">Summary</a>
+      <a href="#daily">Daily Activity</a>
+      <a href="#endpoints">Endpoint Metrics</a>
+      <a href="#geography">Geography</a>
+      <a href="#errors">Errors</a>
+      <a href="#models">LLM Models</a>
+      <a href="/docs">API Docs</a>
+    </nav>
+
+    <h2 id="summary" class="section-title">Summary</h2>
+    <div class="summary">
+      <div class="card">
+        <h3>Endpoints</h3>
+        <div class="value">${summary.totalEndpoints}</div>
+      </div>
+      <div class="card">
+        <h3>Total Calls</h3>
+        <div class="value">${summary.totalCalls.toLocaleString()}</div>
+      </div>
+      <div class="card">
+        <h3>Success Rate</h3>
+        <div class="value success">${summary.avgSuccessRate.toFixed(1)}%</div>
+      </div>
+      <div class="card">
+        <h3>Errors</h3>
+        <div class="value error">${summary.totalErrors.toLocaleString()}</div>
+      </div>
+      <div class="card">
+        <h3>STX Earned</h3>
+        <div class="value stx">${formatSTX(summary.earningsSTX)}</div>
+      </div>
+      <div class="card">
+        <h3>Sats Earned</h3>
+        <div class="value sbtc">${formatSBTC(summary.earningsSBTC)}</div>
+      </div>
+      <div class="card">
+        <h3>USDCx Earned</h3>
+        <div class="value usdcx">$${formatUSDCx(summary.earningsUSDCx)}</div>
+      </div>
+      <div class="card">
+        <h3>Datacenters</h3>
+        <div class="value">${summary.uniqueColos}</div>
+      </div>
+    </div>
+
+    <h2 id="daily" class="section-title">Daily Activity (Last 7 Days)</h2>
+    <div class="chart-container">
+      <div class="bar-chart">
+        ${daily.map((day) => {
+          const successHeight = Math.max((day.successfulCalls / maxDailyCalls) * 100, 2);
+          const errorHeight = Math.max((day.errorCalls / maxDailyCalls) * 100, 0);
+          return `
+            <div class="bar-day">
+              <div class="bar-value">${day.totalCalls.toLocaleString()}</div>
+              <div style="display: flex; flex-direction: column; width: 100%;">
+                <div class="bar" style="height: ${successHeight}px"></div>
+                ${errorHeight > 0 ? `<div class="bar errors" style="height: ${errorHeight}px"></div>` : ""}
+              </div>
+              <div class="bar-label">${day.date.slice(5)}</div>
+            </div>
+          `;
+        }).join("")}
+      </div>
+    </div>
+
+    <h2 id="endpoints" class="section-title">Endpoint Metrics</h2>
+    <div class="table-container">
+      <div class="table-scroll">
+        <table id="endpoints-table">
+          <thead>
+            <tr>
+              <th data-sort="endpoint">Endpoint <span class="sort-icon">↕</span></th>
+              <th data-sort="category">Category <span class="sort-icon">↕</span></th>
+              <th data-sort="calls" class="sorted">Calls <span class="sort-icon">↓</span></th>
+              <th data-sort="success">Success <span class="sort-icon">↕</span></th>
+              <th data-sort="errors">Errors <span class="sort-icon">↕</span></th>
+              <th data-sort="latency">Latency <span class="sort-icon">↕</span></th>
+              <th data-sort="bytes">Data <span class="sort-icon">↕</span></th>
+              <th data-sort="stx">STX <span class="sort-icon">↕</span></th>
+              <th data-sort="lastcall">Last Call <span class="sort-icon">↕</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            ${sortedEndpoints.map((ep) => {
+              const successRate = ep.totalCalls > 0 ? ((ep.successfulCalls / ep.totalCalls) * 100) : 0;
+              const successClass = successRate >= 95 ? "success-high" : successRate >= 80 ? "success-med" : "success-low";
+              const lastCallTs = ep.lastCall ? new Date(ep.lastCall).getTime() : 0;
+              const lastCallDisplay = ep.lastCall ? new Date(ep.lastCall).toLocaleString() : "-";
+              const bytesDisplay = ep.totalBytes > 1048576
+                ? `${(ep.totalBytes / 1048576).toFixed(1)} MB`
+                : ep.totalBytes > 1024
+                  ? `${(ep.totalBytes / 1024).toFixed(1)} KB`
+                  : `${ep.totalBytes} B`;
+
+              return `
+                <tr data-endpoint="${ep.endpoint}" data-category="${ep.category}" data-calls="${ep.totalCalls}" data-success="${successRate.toFixed(1)}" data-errors="${ep.errorCalls}" data-latency="${ep.avgLatencyMs}" data-bytes="${ep.totalBytes}" data-stx="${ep.earningsSTX}" data-lastcall="${lastCallTs}">
+                  <td><code>${ep.endpoint}</code></td>
+                  <td class="${getCategoryClass(ep.category)}">${ep.category}</td>
+                  <td>${ep.totalCalls.toLocaleString()}</td>
+                  <td class="${successClass}">${successRate.toFixed(1)}%</td>
+                  <td>${ep.errorCalls.toLocaleString()}</td>
+                  <td>${ep.avgLatencyMs}ms</td>
+                  <td>${bytesDisplay}</td>
+                  <td>${formatSTX(ep.earningsSTX)}</td>
+                  <td>${lastCallDisplay}</td>
+                </tr>
+              `;
+            }).join("")}
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="grid-2">
+      <div>
+        <h2 id="geography" class="section-title">Geographic Distribution</h2>
+        <div class="chart-container">
+          <div class="chart-title">Requests by Cloudflare Datacenter</div>
+          <div class="colo-grid">
+            ${colos.length > 0 ? colos.map((colo) => `
+              <div class="colo-item">
+                <div class="colo-code">${colo.colo}</div>
+                <div class="colo-count">${colo.totalCalls.toLocaleString()}</div>
+                <div class="colo-latency">${colo.avgLatencyMs}ms</div>
+              </div>
+            `).join("") : `<div style="color: #71717a; padding: 20px;">No data yet</div>`}
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <h2 id="errors" class="section-title">Error Breakdown</h2>
+        <div class="chart-container">
+          <div class="chart-title">Errors by Type</div>
+          <div class="error-list">
+            ${errors.length > 0 ? errors.map((err) => `
+              <div class="error-item">
+                <span class="error-type">${err.errorType}</span>
+                <span class="error-count">${err.count.toLocaleString()} occurrences</span>
+              </div>
+            `).join("") : `<div style="color: #71717a; padding: 20px;">No errors recorded</div>`}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h2 id="models" class="section-title">LLM Model Usage</h2>
+    <div class="chart-container">
+      <div class="model-grid">
+        ${modelStats.length > 0 ? modelStats.map((model) => `
+          <div class="model-card">
+            <div class="model-name">${model.model}</div>
+            <div class="model-stats">
+              <div class="model-stat">
+                <span class="stat-label">Calls</span>
+                <span class="stat-value">${model.totalCalls.toLocaleString()}</span>
+              </div>
+              <div class="model-stat">
+                <span class="stat-label">Input Tokens</span>
+                <span class="stat-value">${model.totalInputTokens.toLocaleString()}</span>
+              </div>
+              <div class="model-stat">
+                <span class="stat-label">Output Tokens</span>
+                <span class="stat-value">${model.totalOutputTokens.toLocaleString()}</span>
+              </div>
+              <div class="model-stat">
+                <span class="stat-label">Revenue (STX)</span>
+                <span class="stat-value">${formatSTX(model.totalEarningsSTX)}</span>
+              </div>
+            </div>
+          </div>
+        `).join("") : `<div style="color: #71717a; padding: 20px;">No LLM usage recorded yet</div>`}
+      </div>
+    </div>
+
+    <div class="footer">
+      <p>
+        <a href="/">Home</a> |
+        <a href="/docs">API Docs</a> |
+        <a href="/health">Health</a> |
+        Built on <a href="https://stacks.co" target="_blank">Stacks</a>
+      </p>
+    </div>
+  </div>
+
+  <script>
+    (function() {
+      const table = document.querySelector('#endpoints-table');
+      if (!table) return;
+
+      const tbody = table.querySelector('tbody');
+      const headers = table.querySelectorAll('th[data-sort]');
+      const numericKeys = ['calls', 'success', 'errors', 'latency', 'bytes', 'stx', 'lastcall'];
+      let currentSort = { key: 'calls', dir: 'desc' };
+
+      function sortTable(key) {
+        const rows = Array.from(tbody.querySelectorAll('tr'));
+        const isNumeric = numericKeys.includes(key);
+
+        if (currentSort.key === key) {
+          currentSort.dir = currentSort.dir === 'asc' ? 'desc' : 'asc';
+        } else {
+          currentSort.key = key;
+          currentSort.dir = isNumeric ? 'desc' : 'asc';
+        }
+
+        rows.sort((a, b) => {
+          let aVal = a.dataset[key];
+          let bVal = b.dataset[key];
+
+          if (isNumeric) {
+            aVal = parseFloat(aVal) || 0;
+            bVal = parseFloat(bVal) || 0;
+            return currentSort.dir === 'asc' ? aVal - bVal : bVal - aVal;
+          } else {
+            return currentSort.dir === 'asc'
+              ? (aVal || '').localeCompare(bVal || '')
+              : (bVal || '').localeCompare(aVal || '');
+          }
+        });
+
+        rows.forEach(row => tbody.appendChild(row));
+
+        headers.forEach(th => {
+          const icon = th.querySelector('.sort-icon');
+          if (th.dataset.sort === key) {
+            th.classList.add('sorted');
+            icon.textContent = currentSort.dir === 'asc' ? '↑' : '↓';
+          } else {
+            th.classList.remove('sorted');
+            icon.textContent = '↕';
+          }
+        });
+      }
+
+      headers.forEach(th => {
+        th.addEventListener('click', () => sortTable(th.dataset.sort));
+      });
+    })();
+  </script>
+</body>
+</html>`;
+}

--- a/src/middleware/metrics.ts
+++ b/src/middleware/metrics.ts
@@ -1,0 +1,241 @@
+/**
+ * Global Metrics Middleware
+ *
+ * Tracks all paid API requests to the global MetricsDO for dashboard analytics.
+ * Records: calls, success/error rates, latency, response size, geographic distribution.
+ */
+
+import type { MiddlewareHandler } from "hono";
+import type { Env, AppVariables, TokenType, PricingTier } from "../types";
+import type { MetricsRecord } from "../durable-objects/MetricsDO";
+import { TIER_PRICING } from "../services/pricing";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface MetricsMiddlewareOptions {
+  /** Pricing tier for this endpoint */
+  tier: PricingTier;
+  /** Category for grouping (e.g., "inference", "stacks", "hashing", "storage") */
+  category: string;
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Normalize endpoint path by removing path parameters
+ * e.g., /stacks/profile/SP123... -> /stacks/profile
+ */
+function normalizeEndpoint(routePath: string): string {
+  return routePath.replace(/\/:[^/]+/g, "");
+}
+
+/**
+ * Classify error types based on status code
+ */
+function classifyError(statusCode: number): string {
+  if (statusCode >= 500) return "server_error";
+  if (statusCode === 402) return "payment_required";
+  if (statusCode === 401 || statusCode === 403) return "auth_error";
+  if (statusCode === 404) return "not_found";
+  if (statusCode === 429) return "rate_limited";
+  if (statusCode >= 400) return "client_error";
+  return "unknown";
+}
+
+/**
+ * Get amount charged based on tier and token type
+ */
+function getAmountCharged(tier: PricingTier, tokenType: TokenType): number {
+  const pricing = TIER_PRICING[tier];
+  if (!pricing) return 0;
+
+  // Convert to micro units for storage
+  // STX: store as microSTX (multiply by 1,000,000)
+  // sBTC: store as sats (multiply by 100,000,000)
+  // USDCx: store as micro units (multiply by 1,000,000)
+  switch (tokenType) {
+    case "STX":
+      return Math.round(pricing.stx * 1_000_000);
+    case "sBTC":
+      // sBTC pricing is in BTC, convert to sats
+      return Math.round(pricing.stx * 100_000_000 * 0.00005); // Approximate STX/BTC ratio
+    case "USDCx":
+      return Math.round(pricing.usd * 1_000_000);
+    default:
+      return 0;
+  }
+}
+
+// =============================================================================
+// Singleton DO Accessor
+// =============================================================================
+
+const METRICS_DO_ID = "global-metrics";
+
+function getMetricsDO(env: Env) {
+  const id = env.METRICS_DO.idFromName(METRICS_DO_ID);
+  return env.METRICS_DO.get(id);
+}
+
+// =============================================================================
+// Middleware Factory
+// =============================================================================
+
+/**
+ * Create metrics tracking middleware for an endpoint
+ *
+ * @example
+ * ```ts
+ * app.post("/hashing/sha256", metricsMiddleware({ tier: "simple", category: "hashing" }), handler);
+ * ```
+ */
+export function metricsMiddleware(
+  options: MetricsMiddlewareOptions
+): MiddlewareHandler<{ Bindings: Env; Variables: AppVariables }> {
+  const { tier, category } = options;
+
+  return async (c, next) => {
+    const startTime = Date.now();
+
+    // Execute the actual handler
+    await next();
+
+    // Only track metrics for paid requests (those with X-PAYMENT header)
+    // This avoids counting 402 responses in metrics
+    const paymentHeader = c.req.header("X-PAYMENT");
+    if (!paymentHeader) return;
+
+    // Calculate metrics
+    const durationMs = Date.now() - startTime;
+    const statusCode = c.res?.status || 500;
+    const isSuccess = statusCode >= 200 && statusCode < 300;
+
+    // Get token type
+    const tokenTypeStr =
+      c.req.header("X-PAYMENT-TOKEN-TYPE") || c.req.query("tokenType") || "STX";
+    const tokenType = (
+      ["STX", "sBTC", "USDCx"].includes(tokenTypeStr) ? tokenTypeStr : "STX"
+    ) as TokenType;
+
+    // Get endpoint path (normalized)
+    const endpoint = normalizeEndpoint(c.req.routePath);
+
+    // Get request metadata
+    const requestId = c.req.header("cf-ray") || crypto.randomUUID();
+    const colo = c.req.header("cf-ipcountry") ||
+                 (c.req.raw as unknown as { cf?: { colo?: string } })?.cf?.colo ||
+                 "UNK";
+
+    // Get response size (approximate from content-length or 0)
+    const responseBytes = parseInt(c.res?.headers.get("content-length") || "0", 10);
+
+    // Get payer address from x402 context
+    const x402Context = c.get("x402");
+    const payerAddress = x402Context?.payerAddress;
+
+    // Get model info for LLM endpoints
+    const model = x402Context?.priceEstimate?.model;
+    const inputTokens = x402Context?.priceEstimate?.estimatedInputTokens;
+    const outputTokens = x402Context?.priceEstimate?.estimatedOutputTokens;
+
+    // Build metrics record
+    const record: MetricsRecord = {
+      requestId,
+      endpoint,
+      category,
+      method: c.req.method,
+      statusCode,
+      isSuccess,
+      errorType: isSuccess ? undefined : classifyError(statusCode),
+      pricingType: tier === "dynamic" ? "dynamic" : "fixed",
+      tier: tier === "dynamic" ? undefined : tier,
+      amountCharged: getAmountCharged(tier, tokenType),
+      token: tokenType,
+      durationMs,
+      responseBytes,
+      colo,
+      payerAddress,
+      model,
+      inputTokens,
+      outputTokens,
+    };
+
+    // Fire-and-forget metrics recording
+    if (c.env.METRICS_DO) {
+      c.executionCtx.waitUntil(
+        (async () => {
+          try {
+            const metricsDO = getMetricsDO(c.env);
+            await metricsDO.recordMetrics(record);
+          } catch (error) {
+            console.error("Failed to record metrics:", error);
+          }
+        })()
+      );
+    }
+  };
+}
+
+// =============================================================================
+// Convenience Middleware Creators
+// =============================================================================
+
+/** Metrics for simple tier endpoints */
+export const metricsSimple = (category: string) =>
+  metricsMiddleware({ tier: "simple", category });
+
+/** Metrics for AI tier endpoints */
+export const metricsAI = (category: string) =>
+  metricsMiddleware({ tier: "ai", category });
+
+/** Metrics for storage read endpoints */
+export const metricsStorageRead = (category: string) =>
+  metricsMiddleware({ tier: "storage_read", category });
+
+/** Metrics for storage write endpoints */
+export const metricsStorageWrite = (category: string) =>
+  metricsMiddleware({ tier: "storage_write", category });
+
+/** Metrics for large storage write endpoints */
+export const metricsStorageWriteLarge = (category: string) =>
+  metricsMiddleware({ tier: "storage_write_large", category });
+
+/** Metrics for dynamic pricing (LLM) endpoints */
+export const metricsDynamic = (category: string) =>
+  metricsMiddleware({ tier: "dynamic", category });
+
+// =============================================================================
+// Dashboard Data Fetcher
+// =============================================================================
+
+/**
+ * Fetch all dashboard data from MetricsDO
+ */
+export async function getDashboardData(env: Env) {
+  const metricsDO = getMetricsDO(env);
+
+  const [summary, endpoints, daily, colos, errors, recentRequests, modelStats] =
+    await Promise.all([
+      metricsDO.getSummary(),
+      metricsDO.getEndpointStats(),
+      metricsDO.getDailyStats(7),
+      metricsDO.getColoStats(),
+      metricsDO.getErrorStats(),
+      metricsDO.getRecentRequests(10),
+      metricsDO.getModelStats(),
+    ]);
+
+  return {
+    summary,
+    endpoints,
+    daily,
+    colos,
+    errors,
+    recentRequests,
+    modelStats,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@
 import type { Context } from "hono";
 import type { UsageDO } from "./durable-objects/UsageDO";
 import type { StorageDO } from "./durable-objects/StorageDO";
+import type { MetricsDO } from "./durable-objects/MetricsDO";
 
 // =============================================================================
 // Logger Types (matching worker-logs RPC interface)
@@ -33,6 +34,7 @@ export interface Env {
   // Durable Objects
   USAGE_DO: DurableObjectNamespace<UsageDO>;
   STORAGE_DO: DurableObjectNamespace<StorageDO>;
+  METRICS_DO: DurableObjectNamespace<MetricsDO>;
   // KV Namespaces
   METRICS: KVNamespace;
   STORAGE: KVNamespace;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,11 +21,13 @@
   "durable_objects": {
     "bindings": [
       { "name": "USAGE_DO", "class_name": "UsageDO" },
-      { "name": "STORAGE_DO", "class_name": "StorageDO" }
+      { "name": "STORAGE_DO", "class_name": "StorageDO" },
+      { "name": "METRICS_DO", "class_name": "MetricsDO" }
     ]
   },
   "migrations": [
-    { "tag": "v1", "new_sqlite_classes": ["UsageDO", "StorageDO"] }
+    { "tag": "v1", "new_sqlite_classes": ["UsageDO", "StorageDO"] },
+    { "tag": "v2", "new_sqlite_classes": ["MetricsDO"] }
   ],
   "vars": {
     "ENVIRONMENT": "development",
@@ -64,7 +66,8 @@
       "durable_objects": {
         "bindings": [
           { "name": "USAGE_DO", "class_name": "UsageDO" },
-          { "name": "STORAGE_DO", "class_name": "StorageDO" }
+          { "name": "STORAGE_DO", "class_name": "StorageDO" },
+          { "name": "METRICS_DO", "class_name": "MetricsDO" }
         ]
       }
     },
@@ -88,7 +91,8 @@
       "durable_objects": {
         "bindings": [
           { "name": "USAGE_DO", "class_name": "UsageDO" },
-          { "name": "STORAGE_DO", "class_name": "StorageDO" }
+          { "name": "STORAGE_DO", "class_name": "StorageDO" },
+          { "name": "METRICS_DO", "class_name": "MetricsDO" }
         ]
       }
     }


### PR DESCRIPTION
## Summary

- Add MetricsDO Durable Object with SQLite for aggregate metrics tracking
- Add `/dashboard` endpoint with HTML UI for real-time analytics
- Integrate global metrics middleware to track all paid requests

## Features

**MetricsDO tracks:**
- Per-request metrics (30-day retention)
- Endpoint aggregates (calls, latency, bytes, earnings by token)
- Daily stats with success/error breakdown
- Geographic distribution by CF datacenter
- Error tracking by type (server_error, client_error, etc.)
- LLM model usage stats (tokens, calls, revenue)

**Dashboard displays:**
- Summary cards (endpoints, calls, success rate, errors, earnings)
- 7-day activity chart with error overlay
- Sortable endpoint metrics table
- Geographic distribution grid
- Error breakdown list
- LLM model usage cards

## Improvements over stx402

| Feature | stx402 | x402-api |
|---------|--------|----------|
| Storage | KV (single key) | SQLite DO |
| Error rates | No | Yes (by type) |
| Response sizes | No | Yes |
| Geographic distribution | No | Yes (CF colo) |
| Per-model LLM stats | No | Yes |

## Test plan

- [ ] Deploy to staging
- [ ] Verify `/dashboard` loads with empty data
- [ ] Make test requests to endpoints
- [ ] Verify metrics appear in dashboard
- [ ] Check geographic distribution populates
- [ ] Verify error tracking works

🤖 Generated with [Claude Code](https://claude.ai/code)