### PR TITLE
fix: update facilitator URL to stacksx402.com

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -4,10 +4,10 @@ A Cloudflare Worker that exposes APIs on a pay-per-use basis using the x402 prot
 
 ## Domains
 
-| Environment | Domain | Network |
-|-------------|--------|---------|
+| Environment    | Domain           | Network |
+| -------------- | ---------------- | ------- |
 | **Production** | `x402.aibtc.com` | mainnet |
-| **Staging** | `x402.aibtc.dev` | testnet |
+| **Staging**    | `x402.aibtc.dev` | testnet |
 
 > **Pattern**: All aibtc hosted projects follow `{service}.aibtc.com` (prod) / `{service}.aibtc.dev` (staging)
 
@@ -15,13 +15,13 @@ A Cloudflare Worker that exposes APIs on a pay-per-use basis using the x402 prot
 
 ## Overview
 
-| Aspect | Value |
-|--------|-------|
-| **Framework** | Chanfana + Hono |
-| **Architecture** | Class-based endpoints |
-| **Pricing** | Hybrid (fixed tiers + dynamic estimation) |
-| **TypeScript** | Strict mode |
-| **Endpoints** | ~41 across 5 categories |
+| Aspect           | Value                                     |
+| ---------------- | ----------------------------------------- |
+| **Framework**    | Chanfana + Hono                           |
+| **Architecture** | Class-based endpoints                     |
+| **Pricing**      | Hybrid (fixed tiers + dynamic estimation) |
+| **TypeScript**   | Strict mode                               |
+| **Endpoints**    | ~41 across 5 categories                   |
 
 ### Payment Flow
 
@@ -51,13 +51,13 @@ A Cloudflare Worker that exposes APIs on a pay-per-use basis using the x402 prot
 
 ### Payment & Pricing (from MVP)
 
-| Decision | Value |
-|----------|-------|
-| **Pricing model** | Fixed tiers OR dynamic (pass-through + 20% margin) |
-| **Payment timing** | Pre-pay based on estimate |
-| **Payment tokens** | STX, sBTC, USDCx (all supported) |
-| **Agent identity** | Stacks address from x402 payment |
-| **DO routing** | `idFromName(stacksAddress)` |
+| Decision           | Value                                              |
+| ------------------ | -------------------------------------------------- |
+| **Pricing model**  | Fixed tiers OR dynamic (pass-through + 20% margin) |
+| **Payment timing** | Pre-pay based on estimate                          |
+| **Payment tokens** | STX, sBTC, USDCx (all supported)                   |
+| **Agent identity** | Stacks address from x402 payment                   |
+| **DO routing**     | `idFromName(stacksAddress)`                        |
 
 ### Pricing Strategy
 
@@ -67,26 +67,26 @@ A Cloudflare Worker that exposes APIs on a pay-per-use basis using the x402 prot
 
 ### Fixed Tiers
 
-| Tier | STX Amount | Use Case |
-|------|------------|----------|
-| `simple` | 0.001 | Basic compute (hashing, conversion) |
-| `ai` | 0.003 | AI-enhanced operations |
-| `heavy_ai` | 0.01 | Heavy AI workloads |
-| `storage_read` | 0.001 | Read from storage |
-| `storage_write` | 0.002 | Write to storage |
-| `storage_write_large` | 0.005 | Large writes (paste, memory) |
+| Tier                  | STX Amount | Use Case                            |
+| --------------------- | ---------- | ----------------------------------- |
+| `simple`              | 0.001      | Basic compute (hashing, conversion) |
+| `ai`                  | 0.003      | AI-enhanced operations              |
+| `heavy_ai`            | 0.01       | Heavy AI workloads                  |
+| `storage_read`        | 0.001      | Read from storage                   |
+| `storage_write`       | 0.002      | Write to storage                    |
+| `storage_write_large` | 0.005      | Large writes (paste, memory)        |
 
 ### Dynamic Pricing (LLM)
 
 ```typescript
 interface PriceEstimate {
-  amount: string;           // In smallest unit (microSTX)
-  token: 'STX' | 'sBTC' | 'USDCx';
+  amount: string; // In smallest unit (microSTX)
+  token: "STX" | "sBTC" | "USDCx";
   breakdown?: {
     inputTokens: number;
     outputTokens: number;
     modelRate: number;
-    margin: number;         // 20%
+    margin: number; // 20%
   };
 }
 ```
@@ -95,26 +95,27 @@ interface PriceEstimate {
 
 ## External API Dependencies
 
-| API | Use Case | Auth | Rate Limits |
-|-----|----------|------|-------------|
-| **Hiro API** | Stacks data (balances, BNS, tx decode) | API key required | Headers: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` |
-| **Tenero API** | Token data, market info | None (public) | Fair use |
-| **OpenRouter** | LLM inference | API key required | Per-model limits |
+| API            | Use Case                               | Auth             | Rate Limits                                                                |
+| -------------- | -------------------------------------- | ---------------- | -------------------------------------------------------------------------- |
+| **Hiro API**   | Stacks data (balances, BNS, tx decode) | API key required | Headers: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` |
+| **Tenero API** | Token data, market info                | None (public)    | Fair use                                                                   |
+| **OpenRouter** | LLM inference                          | API key required | Per-model limits                                                           |
 
 ### Reference Patterns (from stacks-tracker)
 
 Code patterns to reference when implementing `/stacks` endpoints. Rewrite for x402-api (strict TS, conventions) rather than copy directly.
 
-| Pattern | Reference File | Use In x402-api |
-|---------|----------------|-----------------|
-| **Hiro API Client** | `~/dev/whoabuddy/stacks-tracker/src/api/hiro-client.ts` | `src/services/hiro.ts` |
-| **Address Validation** | `~/dev/whoabuddy/stacks-tracker/src/crypto/key-derivation.ts` | Address conversion endpoint |
-| **BNS Detection** | `isBnsName()` in key-derivation.ts | Profile endpoint (resolve names) |
-| **Clarity Value Types** | `~/dev/whoabuddy/stacks-tracker/src/types/clarity-args.ts` | Decode endpoints |
-| **Clarity Converter** | `~/dev/whoabuddy/stacks-tracker/src/utils/clarity-converter.ts` | Decode Clarity hex |
-| **Rate Limit Tracking** | `~/dev/whoabuddy/stacks-tracker/src/api/rate-limiter.ts` | Track Hiro limits (simplified) |
+| Pattern                 | Reference File                                                  | Use In x402-api                  |
+| ----------------------- | --------------------------------------------------------------- | -------------------------------- |
+| **Hiro API Client**     | `~/dev/whoabuddy/stacks-tracker/src/api/hiro-client.ts`         | `src/services/hiro.ts`           |
+| **Address Validation**  | `~/dev/whoabuddy/stacks-tracker/src/crypto/key-derivation.ts`   | Address conversion endpoint      |
+| **BNS Detection**       | `isBnsName()` in key-derivation.ts                              | Profile endpoint (resolve names) |
+| **Clarity Value Types** | `~/dev/whoabuddy/stacks-tracker/src/types/clarity-args.ts`      | Decode endpoints                 |
+| **Clarity Converter**   | `~/dev/whoabuddy/stacks-tracker/src/utils/clarity-converter.ts` | Decode Clarity hex               |
+| **Rate Limit Tracking** | `~/dev/whoabuddy/stacks-tracker/src/api/rate-limiter.ts`        | Track Hiro limits (simplified)   |
 
 **Key Hiro API Endpoints Used:**
+
 ```
 GET  /extended/v1/address/{principal}/stx     - STX balance
 GET  /extended/v1/address/{principal}/nonces  - Account nonces
@@ -124,20 +125,22 @@ POST /v2/transactions                         - Broadcast (if needed)
 ```
 
 **Clarity Type System (JSON-serializable):**
+
 ```typescript
 type ClarityArgument =
-  | { type: 'uint' | 'int'; value: string }
-  | { type: 'bool'; value: boolean }
-  | { type: 'principal'; value: string }
-  | { type: 'string-ascii' | 'string-utf8'; value: string }
-  | { type: 'buffer'; value: string }  // hex-encoded
-  | { type: 'none' }
-  | { type: 'some' | 'ok' | 'err'; value: ClarityArgument }
-  | { type: 'list'; value: ClarityArgument[] }
-  | { type: 'tuple'; value: Record<string, ClarityArgument> }
+  | { type: "uint" | "int"; value: string }
+  | { type: "bool"; value: boolean }
+  | { type: "principal"; value: string }
+  | { type: "string-ascii" | "string-utf8"; value: string }
+  | { type: "buffer"; value: string } // hex-encoded
+  | { type: "none" }
+  | { type: "some" | "ok" | "err"; value: ClarityArgument }
+  | { type: "list"; value: ClarityArgument[] }
+  | { type: "tuple"; value: Record<string, ClarityArgument> };
 ```
 
 **Implementation Notes:**
+
 - Single Hiro API key (no rotation needed initially)
 - Track rate limit headers for client awareness
 - No Chainhooks integration needed (request/response only)
@@ -152,24 +155,28 @@ type ClarityArgument =
 Multi-provider inference with OpenRouter and Cloudflare AI, organized by provider subdirectory.
 
 #### OpenRouter (`/inference/openrouter`)
-| Endpoint | Method | Pricing | Source |
-|----------|--------|---------|--------|
-| `/inference/openrouter/list-models` | GET | Free | x402-api |
-| `/inference/openrouter/chat` | POST | Dynamic (model + tokens) | x402-api |
+
+| Endpoint                            | Method | Pricing                  | Source   |
+| ----------------------------------- | ------ | ------------------------ | -------- |
+| `/inference/openrouter/list-models` | GET    | Free                     | x402-api |
+| `/inference/openrouter/chat`        | POST   | Dynamic (model + tokens) | x402-api |
 
 #### Cloudflare AI (`/inference/cloudflare`)
-| Endpoint | Method | Pricing | Source |
-|----------|--------|---------|--------|
-| `/inference/cloudflare/list-models` | GET | Free | New |
-| `/inference/cloudflare/chat` | POST | Fixed (ai tier) | New |
+
+| Endpoint                            | Method | Pricing         | Source |
+| ----------------------------------- | ------ | --------------- | ------ |
+| `/inference/cloudflare/list-models` | GET    | Free            | New    |
+| `/inference/cloudflare/chat`        | POST   | Fixed (ai tier) | New    |
 
 **OpenRouter Dynamic Pricing** estimates cost based on:
+
 - Model pricing (per 1K input/output tokens)
 - Input token count from messages
 - Output estimate (2x input or max_tokens)
 - 20% margin + minimum floor
 
 **Cloudflare AI Fixed Pricing**:
+
 - Uses `ai` tier (0.003 STX) - CF AI costs are absorbed/amortized
 - Simpler pricing since CF AI is billed to our account monthly
 
@@ -177,35 +184,37 @@ Multi-provider inference with OpenRouter and Cloudflare AI, organized by provide
 
 Useful for agents and apps working with Stacks data.
 
-| Endpoint | Method | Pricing | Source |
-|----------|--------|---------|--------|
-| `/stacks/address/convert` | POST | Fixed (simple) | stx402 |
-| `/stacks/decode/clarity-value` | POST | Fixed (simple) | stx402 |
-| `/stacks/decode/transaction` | POST | Fixed (simple) | stx402 |
-| `/stacks/profile/{address}` | GET | Fixed (simple) | stx402 |
-| `/stacks/verify/message` | POST | Fixed (simple) | New |
-| `/stacks/verify/sip018` | POST | Fixed (simple) | New |
+| Endpoint                       | Method | Pricing        | Source |
+| ------------------------------ | ------ | -------------- | ------ |
+| `/stacks/address/convert`      | POST   | Fixed (simple) | stx402 |
+| `/stacks/decode/clarity-value` | POST   | Fixed (simple) | stx402 |
+| `/stacks/decode/transaction`   | POST   | Fixed (simple) | stx402 |
+| `/stacks/profile/{address}`    | GET    | Fixed (simple) | stx402 |
+| `/stacks/verify/message`       | POST   | Fixed (simple) | New    |
+| `/stacks/verify/sip018`        | POST   | Fixed (simple) | New    |
 
 **Notes:**
+
 - Verify endpoints support simple signed messages and SIP-018 structured data
 - Address input accepts: STX address (SP.../ST...) or BNS name (user.btc)
 
 **Profile Endpoint Response Structure:**
+
 ```typescript
 interface StacksProfile {
   // Input resolution
-  input: string;                    // Original input (address or BNS)
-  address: string;                  // Resolved STX address
-  bnsName?: string;                 // BNS name if registered
+  input: string; // Original input (address or BNS)
+  address: string; // Resolved STX address
+  bnsName?: string; // BNS name if registered
 
   // Chain state (Hiro API)
-  blockHeight: number;              // Current block height
+  blockHeight: number; // Current block height
   stxBalance: {
-    balance: string;                // microSTX
-    locked: string;                 // Stacking locked
+    balance: string; // microSTX
+    locked: string; // Stacking locked
     unlockHeight?: number;
   };
-  nonce: number;                    // Next expected nonce
+  nonce: number; // Next expected nonce
 
   // Token balances (Hiro + Tenero)
   fungibleTokens: Array<{
@@ -213,7 +222,7 @@ interface StacksProfile {
     symbol?: string;
     balance: string;
     decimals?: number;
-    usdValue?: number;              // From Tenero if available
+    usdValue?: number; // From Tenero if available
   }>;
 
   nonFungibleTokens: Array<{
@@ -224,6 +233,7 @@ interface StacksProfile {
 ```
 
 **Data Sources:**
+
 - `blockHeight`, `stxBalance`, `nonce`: Hiro API `/extended/v1/address/{addr}/stx`
 - `bnsName`: Hiro API `/v1/addresses/stacks/{addr}` or reverse lookup
 - `fungibleTokens`: Hiro API `/extended/v1/address/{addr}/balances`
@@ -233,16 +243,17 @@ interface StacksProfile {
 
 Compute-as-a-service for hash functions available in Clarity.
 
-| Endpoint | Method | Pricing | Source |
-|----------|--------|---------|--------|
-| `/hashing/sha256` | POST | Fixed (simple) | stx402 |
-| `/hashing/sha512` | POST | Fixed (simple) | stx402 |
-| `/hashing/sha512-256` | POST | Fixed (simple) | stx402 |
-| `/hashing/keccak256` | POST | Fixed (simple) | stx402 |
-| `/hashing/hash160` | POST | Fixed (simple) | stx402 |
-| `/hashing/ripemd160` | POST | Fixed (simple) | stx402 |
+| Endpoint              | Method | Pricing        | Source |
+| --------------------- | ------ | -------------- | ------ |
+| `/hashing/sha256`     | POST   | Fixed (simple) | stx402 |
+| `/hashing/sha512`     | POST   | Fixed (simple) | stx402 |
+| `/hashing/sha512-256` | POST   | Fixed (simple) | stx402 |
+| `/hashing/keccak256`  | POST   | Fixed (simple) | stx402 |
+| `/hashing/hash160`    | POST   | Fixed (simple) | stx402 |
+| `/hashing/ripemd160`  | POST   | Fixed (simple) | stx402 |
 
 **Notes:**
+
 - All return hex-encoded hash output
 - Input can be hex string or raw bytes
 - Matches Clarity's built-in hash functions exactly
@@ -260,18 +271,19 @@ All stateful/persistent operations organized by subdirectory.
 /storage/memory/*    - Vector memory/embeddings (uses CF AI for embeddings)
 ```
 
-| Subcategory | Endpoints | Pricing | Source |
-|-------------|-----------|---------|--------|
-| **kv** | get, set, delete, list | Fixed (storage_read/write) | stx402 |
-| **paste** | create, get, delete | Fixed (storage_write/read) | stx402 |
-| **db** | query, execute, schema | Fixed (storage_read/write) | stx402 |
-| **sync** | lock, unlock, extend, status, list | Fixed (simple) | stx402 |
-| **queue** | push, pop, peek, status, clear | Fixed (simple) | stx402 |
-| **memory** | store, search, delete, list, clear | Fixed (ai) | stx402 |
+| Subcategory | Endpoints                          | Pricing                    | Source |
+| ----------- | ---------------------------------- | -------------------------- | ------ |
+| **kv**      | get, set, delete, list             | Fixed (storage_read/write) | stx402 |
+| **paste**   | create, get, delete                | Fixed (storage_write/read) | stx402 |
+| **db**      | query, execute, schema             | Fixed (storage_read/write) | stx402 |
+| **sync**    | lock, unlock, extend, status, list | Fixed (simple)             | stx402 |
+| **queue**   | push, pop, peek, status, clear     | Fixed (simple)             | stx402 |
+| **memory**  | store, search, delete, list, clear | Fixed (ai)                 | stx402 |
 
 **Total: 25 storage endpoints**
 
 **Notes:**
+
 - Memory endpoints use CF AI binding for embedding generation
 - All storage is per-payer (isolated by Stacks address via Durable Object)
 
@@ -374,6 +386,7 @@ CREATE TABLE daily_stats (
 ```
 
 ### Dashboard Queries
+
 - Revenue by category/endpoint (daily, weekly, monthly)
 - Top payers by volume
 - Endpoint popularity
@@ -392,9 +405,7 @@ CREATE TABLE daily_stats (
   "compatibility_date": "2025-01-08",
   "observability": { "enabled": true },
 
-  "services": [
-    { "binding": "LOGS", "service": "worker-logs" }
-  ],
+  "services": [{ "binding": "LOGS", "service": "worker-logs" }],
 
   "kv_namespaces": [
     { "binding": "METRICS", "id": "TBD" },
@@ -408,13 +419,11 @@ CREATE TABLE daily_stats (
       { "name": "USAGE_DO", "class_name": "UsageDO" },
       { "name": "STORAGE_DO", "class_name": "StorageDO" }
     ],
-    "migrations": [
-      { "tag": "v1", "new_classes": ["UsageDO", "StorageDO"] }
-    ]
+    "migrations": [{ "tag": "v1", "new_classes": ["UsageDO", "StorageDO"] }]
   },
 
   "vars": {
-    "X402_FACILITATOR_URL": "https://facilitator.x402stacks.xyz",
+    "X402_FACILITATOR_URL": "https://facilitator.stacksx402.com",
     "X402_NETWORK": "mainnet"
   },
 
@@ -434,17 +443,19 @@ CREATE TABLE daily_stats (
 
 ### Secrets (via `wrangler secret put`)
 
-| Secret | Purpose | Required For |
-|--------|---------|--------------|
-| `OPENROUTER_API_KEY` | OpenRouter API access | `/inference/openrouter/*` |
-| `HIRO_API_KEY` | Hiro API access (better rate limits) | `/stacks/*` |
+| Secret               | Purpose                              | Required For              |
+| -------------------- | ------------------------------------ | ------------------------- |
+| `OPENROUTER_API_KEY` | OpenRouter API access                | `/inference/openrouter/*` |
+| `HIRO_API_KEY`       | Hiro API access (better rate limits) | `/stacks/*`               |
 
 **Hiro API Key Setup:**
+
 1. Register at https://platform.hiro.so/
 2. Create API key in dashboard
 3. Set via `wrangler secret put HIRO_API_KEY`
 
 **Rate Limit Headers (Hiro):**
+
 - `X-RateLimit-Limit` - Max requests per window
 - `X-RateLimit-Remaining` - Requests left in window
 - `X-RateLimit-Reset` - Unix timestamp when window resets
@@ -491,6 +502,7 @@ Consider caching these values and returning them in response headers for client 
 ## Implementation Phases
 
 ### Phase 1: Core Infrastructure
+
 - [ ] Update `wrangler.jsonc` (KV, AI, DOs, domains)
 - [ ] Add dependencies (chanfana, zod)
 - [ ] Create `src/endpoints/base.ts` with pricing strategy
@@ -499,11 +511,13 @@ Consider caching these values and returning them in response headers for client 
 - [ ] Set up Scalar docs at `/docs`
 
 ### Phase 2: Durable Objects
+
 - [ ] Create `UsageDO` with schema and RPC methods
 - [ ] Create `StorageDO` (or adapt from stx402's UserDurableObject)
 - [ ] Add metrics middleware for usage tracking
 
 ### Phase 3: Inference Endpoints
+
 - [ ] Create `/inference/openrouter/` directory structure
 - [ ] Migrate OpenRouter list-models (free) from x402-api
 - [ ] Migrate OpenRouter chat (dynamic pricing) from x402-api
@@ -513,6 +527,7 @@ Consider caching these values and returning them in response headers for client 
 - [ ] Test payment flows (dynamic + fixed)
 
 ### Phase 4: Stacks Endpoints
+
 - [ ] Create `src/services/hiro.ts` (API client with rate limit tracking)
 - [ ] Create `src/services/tenero.ts` (API client)
 - [ ] Set up HIRO_API_KEY secret
@@ -522,10 +537,12 @@ Consider caching these values and returning them in response headers for client 
 - [ ] Create signature verification endpoints (message + SIP-018)
 
 ### Phase 5: Hashing Endpoints
+
 - [ ] Migrate all 6 hash endpoints from stx402
 - [ ] Verify Clarity compatibility
 
 ### Phase 6: Storage Endpoints
+
 - [ ] Set up storage subdirectory structure
 - [ ] Migrate KV endpoints (4)
 - [ ] Migrate paste endpoints (3)
@@ -535,6 +552,7 @@ Consider caching these values and returning them in response headers for client 
 - [ ] Migrate memory endpoints (5)
 
 ### Phase 7: Testing & Documentation
+
 - [ ] End-to-end payment tests (fixed + dynamic)
 - [ ] Usage tracking verification
 - [ ] OpenAPI documentation review
@@ -544,26 +562,28 @@ Consider caching these values and returning them in response headers for client 
 
 ## Resolved Decisions
 
-| Question | Decision |
-|----------|----------|
-| Storage subdirectories? | ✅ Yes - `/storage/kv/*`, `/storage/paste/*`, etc. |
-| Keep vector embeddings? | ✅ Yes - uses CF AI for embedding generation |
-| Inference provider separation? | ✅ Subdirectories: `/inference/openrouter/*`, `/inference/cloudflare/*` |
-| Stacks profile APIs? | ✅ Hiro API (with API key) + Tenero API |
-| Code reuse from stacks-tracker? | ✅ Reference patterns, rewrite fresh |
-| Hiro API key rotation? | ✅ Single key (no rotation initially) |
-| Chainhooks integration? | ✅ Not needed (request/response only) |
+| Question                        | Decision                                                                |
+| ------------------------------- | ----------------------------------------------------------------------- |
+| Storage subdirectories?         | ✅ Yes - `/storage/kv/*`, `/storage/paste/*`, etc.                      |
+| Keep vector embeddings?         | ✅ Yes - uses CF AI for embedding generation                            |
+| Inference provider separation?  | ✅ Subdirectories: `/inference/openrouter/*`, `/inference/cloudflare/*` |
+| Stacks profile APIs?            | ✅ Hiro API (with API key) + Tenero API                                 |
+| Code reuse from stacks-tracker? | ✅ Reference patterns, rewrite fresh                                    |
+| Hiro API key rotation?          | ✅ Single key (no rotation initially)                                   |
+| Chainhooks integration?         | ✅ Not needed (request/response only)                                   |
 
 ---
 
 ## Open Questions
 
 1. **Free endpoints**: Which endpoints should be free (no payment)?
+
    - Confirmed free: `/inference/openrouter/list-models`, `/inference/cloudflare/list-models`
    - Consider: `/health`, `/docs`, OpenAPI spec endpoint
    - **Decision needed**: Any others?
 
 2. **Rate limiting**: Add per-payer rate limits beyond payment?
+
    - Could use UsageDO to track request counts
    - Prevent abuse even with valid payments
    - **Decision needed**: Implement now or defer?
@@ -582,21 +602,21 @@ Consider caching these values and returning them in response headers for client 
 
 ### Must Have Before Launch
 
-| Blocker | Status | Owner | Notes |
-|---------|--------|-------|-------|
-| Hiro API key | ⏳ Pending | - | Register at platform.hiro.so |
-| KV namespace IDs | ⏳ Pending | - | Create via `wrangler kv:namespace create` |
-| Domain DNS setup | ⏳ Pending | - | x402.aibtc.com, x402.aibtc.dev |
-| worker-logs service | ✅ Exists | - | Already deployed at wbd.host |
+| Blocker             | Status     | Owner | Notes                                     |
+| ------------------- | ---------- | ----- | ----------------------------------------- |
+| Hiro API key        | ⏳ Pending | -     | Register at platform.hiro.so              |
+| KV namespace IDs    | ⏳ Pending | -     | Create via `wrangler kv:namespace create` |
+| Domain DNS setup    | ⏳ Pending | -     | x402.aibtc.com, x402.aibtc.dev            |
+| worker-logs service | ✅ Exists  | -     | Already deployed at wbd.host              |
 
 ### Should Verify
 
-| Item | Risk | Mitigation |
-|------|------|------------|
-| Chanfana + strict TS | Medium | May need type adjustments from stx402 |
-| DO migration from x402-api | Low | OpenRouterDO → UsageDO schema change |
-| OpenRouter streaming | Low | Already working in x402-api |
-| CF AI model availability | Low | Check available models match needs |
+| Item                       | Risk   | Mitigation                            |
+| -------------------------- | ------ | ------------------------------------- |
+| Chanfana + strict TS       | Medium | May need type adjustments from stx402 |
+| DO migration from x402-api | Low    | OpenRouterDO → UsageDO schema change  |
+| OpenRouter streaming       | Low    | Already working in x402-api           |
+| CF AI model availability   | Low    | Check available models match needs    |
 
 ### Nice to Have (Can Defer)
 
@@ -609,15 +629,16 @@ Consider caching these values and returning them in response headers for client 
 
 ## Endpoint Count Summary
 
-| Category | Count | Pricing | Free |
-|----------|-------|---------|------|
-| inference | 4 | Mixed (dynamic + fixed) | 2 (list-models) |
-| stacks | 6 | Fixed | 0 |
-| hashing | 6 | Fixed | 0 |
-| storage | 25 | Fixed | 0 |
-| **Total** | **41** | Mixed | **2** |
+| Category  | Count  | Pricing                 | Free            |
+| --------- | ------ | ----------------------- | --------------- |
+| inference | 4      | Mixed (dynamic + fixed) | 2 (list-models) |
+| stacks    | 6      | Fixed                   | 0               |
+| hashing   | 6      | Fixed                   | 0               |
+| storage   | 25     | Fixed                   | 0               |
+| **Total** | **41** | Mixed                   | **2**           |
 
 Plus system endpoints (always free):
+
 - `GET /` - Service info
 - `GET /health` - Health check
 - `GET /docs` - Scalar OpenAPI UI
@@ -627,27 +648,32 @@ Plus system endpoints (always free):
 ## Resources
 
 ### x402 Protocol
+
 - [x402 Protocol](https://www.x402.org/)
 - [x402 GitHub](https://github.com/coinbase/x402)
 - [x402-stacks npm](https://www.npmjs.com/package/x402-stacks)
 
 ### Cloudflare
+
 - [Durable Objects](https://developers.cloudflare.com/durable-objects/)
 - [SQLite in DOs](https://developers.cloudflare.com/durable-objects/api/sqlite-storage-api/)
 - [Service Bindings](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/)
 - [Workers AI](https://developers.cloudflare.com/workers-ai/)
 
 ### OpenRouter
+
 - [API Reference](https://openrouter.ai/docs/api/reference/overview)
 - [Streaming](https://openrouter.ai/docs/api/reference/streaming)
 - [Usage Accounting](https://openrouter.ai/docs/use-cases/usage-accounting)
 
 ### Stacks
+
 - [Hiro API](https://docs.hiro.so/stacks/api)
 - [Tenero API](https://docs.tenero.io/)
 - [@stacks/transactions](https://github.com/hirosystems/stacks.js/tree/main/packages/transactions)
 
 ### Local References
+
 - `~/dev/whoabuddy/stacks-tracker/` - Hiro client, Clarity types, rate limiting patterns
 - `~/dev/whoabuddy/stx402/` - Production endpoints to migrate
 - `~/dev/whoabuddy/worker-logs/` - Universal logging service

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -14,8 +14,16 @@
    * These are NOT inherited by environments - each env must define its own.
    */
   "kv_namespaces": [
-    { "binding": "METRICS", "id": "3f11905fdf2346a59822bd412601b789", "preview_id": "3f11905fdf2346a59822bd412601b789" },
-    { "binding": "STORAGE", "id": "e53ab39b253041de87dbebf2fedbb6b3", "preview_id": "e53ab39b253041de87dbebf2fedbb6b3" }
+    {
+      "binding": "METRICS",
+      "id": "3f11905fdf2346a59822bd412601b789",
+      "preview_id": "3f11905fdf2346a59822bd412601b789"
+    },
+    {
+      "binding": "STORAGE",
+      "id": "e53ab39b253041de87dbebf2fedbb6b3",
+      "preview_id": "e53ab39b253041de87dbebf2fedbb6b3"
+    }
   ],
   "ai": { "binding": "AI" },
   "durable_objects": {
@@ -31,7 +39,7 @@
   ],
   "vars": {
     "ENVIRONMENT": "development",
-    "X402_FACILITATOR_URL": "https://facilitator.x402stacks.xyz",
+    "X402_FACILITATOR_URL": "https://facilitator.stacksx402.com",
     "X402_NETWORK": "testnet",
     "X402_SERVER_ADDRESS": "ST37NMC4HGFQ1H2JSFP4H3TMNQBF4PY0MVSD1GV7Z"
   },
@@ -53,7 +61,7 @@
       "observability": { "enabled": true },
       "vars": {
         "ENVIRONMENT": "staging",
-        "X402_FACILITATOR_URL": "https://facilitator.x402stacks.xyz",
+        "X402_FACILITATOR_URL": "https://facilitator.stacksx402.com",
         "X402_NETWORK": "testnet",
         "X402_SERVER_ADDRESS": "ST37NMC4HGFQ1H2JSFP4H3TMNQBF4PY0MVSD1GV7Z"
       },
@@ -78,7 +86,7 @@
       "observability": { "enabled": true },
       "vars": {
         "ENVIRONMENT": "production",
-        "X402_FACILITATOR_URL": "https://facilitator.x402stacks.xyz",
+        "X402_FACILITATOR_URL": "https://facilitator.stacksx402.com",
         "X402_NETWORK": "mainnet",
         "X402_SERVER_ADDRESS": "SP37NMC4HGFQ1H2JSFP4H3TMNQBF4PY0MVRHQXGQE"
       },


### PR DESCRIPTION
## Summary
- Update X402_FACILITATOR_URL from `facilitator.x402stacks.xyz` to `facilitator.stacksx402.com`
- Applied to wrangler.jsonc (dev, staging, production environments)
- Updated REQUIREMENTS.md documentation to match

## Test plan
- [ ] Verify wrangler dev runs with new facilitator URL
- [ ] Confirm facilitator.stacksx402.com is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)