### PR TITLE
fix: add BigInt.toJSON polyfill for x402 payment serialization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,9 @@
+// Polyfill BigInt.toJSON for JSON.stringify compatibility (stacks.js uses BigInt extensively)
+// This must be at the top before any other imports that might use BigInt
+(BigInt.prototype as any).toJSON = function () {
+  return this.toString();
+};
+
 /**
  * x402 Stacks API Host
  *


### PR DESCRIPTION
## Summary
- Add `BigInt.prototype.toJSON` polyfill to fix JSON serialization errors from x402-stacks library
- Improve test error logging to show actual error messages instead of generic "Rate limited"
- Add `exceptionMessage` to error response details for better debugging

## Problem
The x402-stacks library returns BigInt values in settle results, causing `JSON.stringify` to throw:
```
TypeError: Do not know how to serialize a BigInt
```

This caused all payment verifications to fail with a generic "Payment processing error" (500).

## Solution
Borrowed the fix from the stx402 repo - a global `BigInt.prototype.toJSON` polyfill at the top of `src/index.ts` that converts BigInt values to strings during JSON serialization.

## Test Results
- **STX**: ✅ All tests pass locally
- **sBTC**: ❌ Fails due to facilitator 500 errors (infrastructure issue)
- **USDCx**: ❌ Fails with "NoSuchContract" (contract not deployed on testnet)

## Test plan
- [x] Type check passes (`npm run check`)
- [x] Local dev server tested with STX payments
- [x] Hashing endpoints verified working with STX

🤖 Generated with [Claude Code](https://claude.ai/code)