### PR TITLE
feat: add lifecycle tests for all storage categories

### DIFF
--- a/src/endpoints/dashboard.ts
+++ b/src/endpoints/dashboard.ts
@@ -75,7 +75,7 @@ export class Dashboard extends OpenAPIRoute {
       };
     }
 
-    const html = generateDashboardHTML(dashboardData, c.env.ENVIRONMENT);
+    const html = generateDashboardHTML(dashboardData, c.env.X402_NETWORK);
     return c.html(html);
   }
 }
@@ -218,8 +218,8 @@ function generateDashboardHTML(data: DashboardData, environment: string): string
     }
     h1 .accent { color: var(--accent); }
     .env-badge {
-      background: ${environment === "production" ? "#166534" : "#1e3a5f"};
-      color: ${environment === "production" ? "#4ade80" : "#60a5fa"};
+      background: ${environment === "mainnet" ? "#166534" : "#1e3a5f"};
+      color: ${environment === "mainnet" ? "#4ade80" : "#60a5fa"};
       padding: 6px 12px;
       border-radius: 6px;
       font-size: 12px;

--- a/tests/_run_all_tests.ts
+++ b/tests/_run_all_tests.ts
@@ -53,11 +53,11 @@ import {
 
 // Import lifecycle test runners
 import { runKvLifecycle } from "./kv-lifecycle.test";
-// import { runPasteLifecycle } from "./paste-lifecycle.test";
-// import { runDbLifecycle } from "./db-lifecycle.test";
-// import { runSyncLifecycle } from "./sync-lifecycle.test";
-// import { runQueueLifecycle } from "./queue-lifecycle.test";
-// import { runMemoryLifecycle } from "./memory-lifecycle.test";
+import { runPasteLifecycle } from "./paste-lifecycle.test";
+import { runDbLifecycle } from "./db-lifecycle.test";
+import { runSyncLifecycle } from "./sync-lifecycle.test";
+import { runQueueLifecycle } from "./queue-lifecycle.test";
+import { runMemoryLifecycle } from "./memory-lifecycle.test";
 
 // =============================================================================
 // Lifecycle Test Mapping (add as lifecycle tests are created)
@@ -68,12 +68,11 @@ const LIFECYCLE_RUNNERS: Record<
   (verbose?: boolean) => Promise<{ passed: number; total: number; success: boolean }>
 > = {
   kv: runKvLifecycle,
-  // Uncomment as lifecycle tests are added:
-  // paste: runPasteLifecycle,
-  // db: runDbLifecycle,
-  // sync: runSyncLifecycle,
-  // queue: runQueueLifecycle,
-  // memory: runMemoryLifecycle,
+  paste: runPasteLifecycle,
+  db: runDbLifecycle,
+  sync: runSyncLifecycle,
+  queue: runQueueLifecycle,
+  memory: runMemoryLifecycle,
 };
 
 // =============================================================================

--- a/tests/db-lifecycle.test.ts
+++ b/tests/db-lifecycle.test.ts
@@ -1,0 +1,338 @@
+#!/usr/bin/env bun
+/**
+ * DB Storage Lifecycle Test
+ *
+ * Tests the complete lifecycle of database storage operations:
+ * 1. Execute (create a table)
+ * 2. Execute (insert data)
+ * 3. Query (select data)
+ * 4. Schema (verify table exists)
+ * 5. Execute (drop table to clean up)
+ */
+
+import type { TokenType } from "x402-stacks";
+import { X402PaymentClient } from "x402-stacks";
+import { deriveChildAccount } from "../src/utils/wallet";
+import {
+  X402_CLIENT_PK,
+  X402_NETWORK,
+  X402_WORKER_URL,
+  createTestLogger,
+  STEP_DELAY_MS,
+  generateTestId,
+  DEFAULT_MAX_RETRIES,
+  isRetryableError,
+  calculateBackoff,
+  sleep,
+  isTerminalStatus,
+  parseErrorResponse,
+  parseResponseData,
+} from "./_shared_utils";
+
+interface X402PaymentRequired {
+  maxAmountRequired: string;
+  resource: string;
+  payTo: string;
+  network: "mainnet" | "testnet";
+  nonce: string;
+  expiresAt: string;
+  tokenType: TokenType;
+}
+
+/** JSON-serializable body type */
+type JsonBody =
+  | Record<string, unknown>
+  | unknown[]
+  | string
+  | number
+  | boolean
+  | null;
+
+async function makeX402Request(
+  x402Client: X402PaymentClient,
+  endpoint: string,
+  method: "GET" | "POST" | "DELETE",
+  body: JsonBody | undefined,
+  tokenType: TokenType,
+  logger: ReturnType<typeof createTestLogger>,
+  maxRetries: number = DEFAULT_MAX_RETRIES
+): Promise<{ status: number; data: unknown }> {
+  const url = `${X402_WORKER_URL}${endpoint}?tokenType=${tokenType}`;
+
+  // Track last error for retry exhaustion reporting
+  let lastErrorStatus = 0;
+  let lastErrorData: unknown = "Failed to get payment requirement";
+
+  // Retry loop for initial request (get 402 payment requirement)
+  let initialRes: Response | null = null;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      initialRes = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      // 402 is expected - break to continue payment flow
+      if (initialRes.status === 402) break;
+
+      // Terminal status codes (200, 404) - return immediately
+      if (isTerminalStatus(initialRes.status)) {
+        const text = await initialRes.text();
+        return { status: initialRes.status, data: parseResponseData(text) };
+      }
+
+      // Parse error and check if retryable
+      const text = await initialRes.text();
+      const errorInfo = parseErrorResponse(text);
+      lastErrorStatus = initialRes.status;
+      lastErrorData = parseResponseData(text);
+
+      if (isRetryableError(initialRes.status, errorInfo.errorCode, errorInfo.errorMessage || text) && attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt, errorInfo.retryAfterSecs);
+        logger.debug(`Initial request failed (${initialRes.status}), retry ${attempt + 1}/${maxRetries} in ${delayMs}ms`);
+        await sleep(delayMs);
+        continue;
+      }
+
+      // Non-retryable error - return last captured error
+      return { status: lastErrorStatus, data: lastErrorData };
+    } catch (fetchError) {
+      lastErrorStatus = 0;
+      lastErrorData = { error: String(fetchError), code: "NETWORK_ERROR" };
+
+      if (attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt);
+        logger.debug(`Fetch error, retry ${attempt + 1}/${maxRetries} in ${delayMs}ms: ${fetchError}`);
+        await sleep(delayMs);
+        continue;
+      }
+      return { status: lastErrorStatus, data: lastErrorData };
+    }
+  }
+
+  // Check if we got a 402 payment requirement
+  if (!initialRes || initialRes.status !== 402) {
+    return { status: lastErrorStatus, data: lastErrorData };
+  }
+
+  const paymentReq: X402PaymentRequired = await initialRes.json();
+  logger.debug("402 Payment req", paymentReq);
+
+  const signResult = await x402Client.signPayment(paymentReq);
+  logger.debug("Signed payment", signResult);
+
+  // Reset error tracking for paid request phase
+  lastErrorStatus = 0;
+  lastErrorData = "Exhausted retries on paid request";
+
+  // Retry loop for paid request
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const retryRes = await fetch(url, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          "X-PAYMENT": signResult.signedTransaction,
+          "X-PAYMENT-TOKEN-TYPE": tokenType,
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      // Terminal status codes (200, 404) - return immediately
+      if (isTerminalStatus(retryRes.status)) {
+        const text = await retryRes.text();
+        return { status: retryRes.status, data: parseResponseData(text) };
+      }
+
+      // Parse error and check if retryable
+      const text = await retryRes.text();
+      const errorInfo = parseErrorResponse(text);
+      lastErrorStatus = retryRes.status;
+      lastErrorData = parseResponseData(text);
+
+      if (isRetryableError(retryRes.status, errorInfo.errorCode, errorInfo.errorMessage || text) && attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt, errorInfo.retryAfterSecs);
+        logger.debug(`Paid request failed (${retryRes.status}), retry ${attempt + 1}/${maxRetries} in ${delayMs}ms`);
+        await sleep(delayMs);
+        continue;
+      }
+
+      // Non-retryable error - return last captured error
+      return { status: lastErrorStatus, data: lastErrorData };
+    } catch (fetchError) {
+      lastErrorStatus = 0;
+      lastErrorData = { error: String(fetchError), code: "NETWORK_ERROR" };
+
+      if (attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt);
+        logger.debug(`Fetch error on paid request, retry ${attempt + 1}/${maxRetries} in ${delayMs}ms: ${fetchError}`);
+        await sleep(delayMs);
+        continue;
+      }
+      return { status: lastErrorStatus, data: lastErrorData };
+    }
+  }
+
+  // Exhausted retries - return last captured error
+  return { status: lastErrorStatus, data: lastErrorData };
+}
+
+export interface LifecycleTestResult {
+  passed: number;
+  total: number;
+  success: boolean;
+}
+
+export async function runDbLifecycle(verbose = false): Promise<LifecycleTestResult> {
+  if (!X402_CLIENT_PK) {
+    throw new Error("Set X402_CLIENT_PK env var with mnemonic");
+  }
+
+  const { address, key } = await deriveChildAccount(X402_NETWORK, X402_CLIENT_PK, 0);
+  const logger = createTestLogger("db-lifecycle", verbose);
+  logger.info(`Test wallet address: ${address}`);
+
+  const x402Client = new X402PaymentClient({
+    network: X402_NETWORK,
+    privateKey: key,
+  });
+
+  // Test with STX only to save on payments
+  const tokenType: TokenType = "STX";
+  // Generate unique table name to avoid conflicts
+  const tableName = `test_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+  let successCount = 0;
+  const totalTests = 5;
+
+  // Test 1: Create table
+  logger.info("1. Testing /storage/db/execute (POST - create table)...");
+  const createResult = await makeX402Request(
+    x402Client,
+    "/storage/db/execute",
+    "POST",
+    { query: `CREATE TABLE ${tableName} (id INTEGER PRIMARY KEY, name TEXT, value TEXT)` },
+    tokenType,
+    logger
+  );
+
+  const createData = createResult.data as { ok?: boolean; rowsAffected?: number };
+  if (createResult.status === 200 && createData.ok) {
+    logger.success(`Created table "${tableName}"`);
+    successCount++;
+  } else {
+    logger.error(`Create table failed: ${JSON.stringify(createResult.data)}`);
+    logger.info("Bailing out: initial create failed, skipping remaining tests");
+    logger.summary(0, totalTests);
+    return { passed: 0, total: totalTests, success: false };
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 2: Insert data
+  logger.info("2. Testing /storage/db/execute (POST - insert)...");
+  const insertResult = await makeX402Request(
+    x402Client,
+    "/storage/db/execute",
+    "POST",
+    { query: `INSERT INTO ${tableName} (id, name, value) VALUES (1, 'test', 'hello world')` },
+    tokenType,
+    logger
+  );
+
+  const insertData = insertResult.data as { ok?: boolean; rowsAffected?: number };
+  if (insertResult.status === 200 && insertData.ok && insertData.rowsAffected === 1) {
+    logger.success(`Inserted 1 row into "${tableName}"`);
+    successCount++;
+  } else {
+    logger.error(`Insert failed: ${JSON.stringify(insertResult.data)}`);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 3: Query data
+  logger.info("3. Testing /storage/db/query (POST - select)...");
+  const queryResult = await makeX402Request(
+    x402Client,
+    "/storage/db/query",
+    "POST",
+    { query: `SELECT * FROM ${tableName} WHERE id = 1` },
+    tokenType,
+    logger
+  );
+
+  const queryData = queryResult.data as { ok?: boolean; rows?: unknown[]; columns?: string[] };
+  if (
+    queryResult.status === 200 &&
+    queryData.ok &&
+    Array.isArray(queryData.rows) &&
+    queryData.rows.length === 1
+  ) {
+    logger.success(`Query returned 1 row`);
+    successCount++;
+  } else {
+    logger.error(`Query failed: ${JSON.stringify(queryResult.data)}`);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 4: Get schema
+  logger.info("4. Testing /storage/db/schema (GET)...");
+  const schemaResult = await makeX402Request(
+    x402Client,
+    "/storage/db/schema",
+    "GET",
+    null,
+    tokenType,
+    logger
+  );
+
+  const schemaData = schemaResult.data as { ok?: boolean; tables?: Array<{ name: string }> };
+  if (schemaResult.status === 200 && schemaData.ok && Array.isArray(schemaData.tables)) {
+    const foundTable = schemaData.tables.find((t) => t.name === tableName);
+    if (foundTable) {
+      logger.success(`Schema shows table "${tableName}" exists`);
+      successCount++;
+    } else {
+      logger.error(`Schema returned but test table not found`);
+    }
+  } else {
+    logger.error(`Schema failed: ${JSON.stringify(schemaResult.data)}`);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 5: Drop table (cleanup)
+  logger.info("5. Testing /storage/db/execute (POST - drop table)...");
+  const dropResult = await makeX402Request(
+    x402Client,
+    "/storage/db/execute",
+    "POST",
+    { query: `DROP TABLE ${tableName}` },
+    tokenType,
+    logger
+  );
+
+  const dropData = dropResult.data as { ok?: boolean };
+  if (dropResult.status === 200 && dropData.ok) {
+    logger.success(`Dropped table "${tableName}"`);
+    successCount++;
+  } else {
+    logger.error(`Drop table failed: ${JSON.stringify(dropResult.data)}`);
+  }
+
+  logger.summary(successCount, totalTests);
+  return { passed: successCount, total: totalTests, success: successCount === totalTests };
+}
+
+// Run if executed directly
+if (import.meta.main) {
+  const verbose = process.argv.includes("-v") || process.argv.includes("--verbose");
+  runDbLifecycle(verbose)
+    .then((result) => process.exit(result.success ? 0 : 1))
+    .catch((err) => {
+      console.error("Test failed:", err);
+      process.exit(1);
+    });
+}

--- a/tests/memory-lifecycle.test.ts
+++ b/tests/memory-lifecycle.test.ts
@@ -1,0 +1,361 @@
+#!/usr/bin/env bun
+/**
+ * Memory (Vector Storage) Lifecycle Test
+ *
+ * Tests the complete lifecycle of memory/vector storage operations:
+ * 1. Store (add items with embeddings)
+ * 2. List (verify items exist)
+ * 3. Search (semantic similarity search)
+ * 4. Delete (remove specific items)
+ * 5. Clear (remove all items)
+ * 6. List (verify empty)
+ */
+
+import type { TokenType } from "x402-stacks";
+import { X402PaymentClient } from "x402-stacks";
+import { deriveChildAccount } from "../src/utils/wallet";
+import {
+  X402_CLIENT_PK,
+  X402_NETWORK,
+  X402_WORKER_URL,
+  createTestLogger,
+  STEP_DELAY_MS,
+  generateTestId,
+  DEFAULT_MAX_RETRIES,
+  isRetryableError,
+  calculateBackoff,
+  sleep,
+  isTerminalStatus,
+  parseErrorResponse,
+  parseResponseData,
+} from "./_shared_utils";
+
+interface X402PaymentRequired {
+  maxAmountRequired: string;
+  resource: string;
+  payTo: string;
+  network: "mainnet" | "testnet";
+  nonce: string;
+  expiresAt: string;
+  tokenType: TokenType;
+}
+
+/** JSON-serializable body type */
+type JsonBody =
+  | Record<string, unknown>
+  | unknown[]
+  | string
+  | number
+  | boolean
+  | null;
+
+async function makeX402Request(
+  x402Client: X402PaymentClient,
+  endpoint: string,
+  method: "GET" | "POST" | "DELETE",
+  body: JsonBody | undefined,
+  tokenType: TokenType,
+  logger: ReturnType<typeof createTestLogger>,
+  maxRetries: number = DEFAULT_MAX_RETRIES
+): Promise<{ status: number; data: unknown }> {
+  const url = `${X402_WORKER_URL}${endpoint}?tokenType=${tokenType}`;
+
+  // Track last error for retry exhaustion reporting
+  let lastErrorStatus = 0;
+  let lastErrorData: unknown = "Failed to get payment requirement";
+
+  // Retry loop for initial request (get 402 payment requirement)
+  let initialRes: Response | null = null;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      initialRes = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      // 402 is expected - break to continue payment flow
+      if (initialRes.status === 402) break;
+
+      // Terminal status codes (200, 404) - return immediately
+      if (isTerminalStatus(initialRes.status)) {
+        const text = await initialRes.text();
+        return { status: initialRes.status, data: parseResponseData(text) };
+      }
+
+      // Parse error and check if retryable
+      const text = await initialRes.text();
+      const errorInfo = parseErrorResponse(text);
+      lastErrorStatus = initialRes.status;
+      lastErrorData = parseResponseData(text);
+
+      if (isRetryableError(initialRes.status, errorInfo.errorCode, errorInfo.errorMessage || text) && attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt, errorInfo.retryAfterSecs);
+        logger.debug(`Initial request failed (${initialRes.status}), retry ${attempt + 1}/${maxRetries} in ${delayMs}ms`);
+        await sleep(delayMs);
+        continue;
+      }
+
+      // Non-retryable error - return last captured error
+      return { status: lastErrorStatus, data: lastErrorData };
+    } catch (fetchError) {
+      lastErrorStatus = 0;
+      lastErrorData = { error: String(fetchError), code: "NETWORK_ERROR" };
+
+      if (attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt);
+        logger.debug(`Fetch error, retry ${attempt + 1}/${maxRetries} in ${delayMs}ms: ${fetchError}`);
+        await sleep(delayMs);
+        continue;
+      }
+      return { status: lastErrorStatus, data: lastErrorData };
+    }
+  }
+
+  // Check if we got a 402 payment requirement
+  if (!initialRes || initialRes.status !== 402) {
+    return { status: lastErrorStatus, data: lastErrorData };
+  }
+
+  const paymentReq: X402PaymentRequired = await initialRes.json();
+  logger.debug("402 Payment req", paymentReq);
+
+  const signResult = await x402Client.signPayment(paymentReq);
+  logger.debug("Signed payment", signResult);
+
+  // Reset error tracking for paid request phase
+  lastErrorStatus = 0;
+  lastErrorData = "Exhausted retries on paid request";
+
+  // Retry loop for paid request
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const retryRes = await fetch(url, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          "X-PAYMENT": signResult.signedTransaction,
+          "X-PAYMENT-TOKEN-TYPE": tokenType,
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      // Terminal status codes (200, 404) - return immediately
+      if (isTerminalStatus(retryRes.status)) {
+        const text = await retryRes.text();
+        return { status: retryRes.status, data: parseResponseData(text) };
+      }
+
+      // Parse error and check if retryable
+      const text = await retryRes.text();
+      const errorInfo = parseErrorResponse(text);
+      lastErrorStatus = retryRes.status;
+      lastErrorData = parseResponseData(text);
+
+      if (isRetryableError(retryRes.status, errorInfo.errorCode, errorInfo.errorMessage || text) && attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt, errorInfo.retryAfterSecs);
+        logger.debug(`Paid request failed (${retryRes.status}), retry ${attempt + 1}/${maxRetries} in ${delayMs}ms`);
+        await sleep(delayMs);
+        continue;
+      }
+
+      // Non-retryable error - return last captured error
+      return { status: lastErrorStatus, data: lastErrorData };
+    } catch (fetchError) {
+      lastErrorStatus = 0;
+      lastErrorData = { error: String(fetchError), code: "NETWORK_ERROR" };
+
+      if (attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt);
+        logger.debug(`Fetch error on paid request, retry ${attempt + 1}/${maxRetries} in ${delayMs}ms: ${fetchError}`);
+        await sleep(delayMs);
+        continue;
+      }
+      return { status: lastErrorStatus, data: lastErrorData };
+    }
+  }
+
+  // Exhausted retries - return last captured error
+  return { status: lastErrorStatus, data: lastErrorData };
+}
+
+export interface LifecycleTestResult {
+  passed: number;
+  total: number;
+  success: boolean;
+}
+
+export async function runMemoryLifecycle(verbose = false): Promise<LifecycleTestResult> {
+  if (!X402_CLIENT_PK) {
+    throw new Error("Set X402_CLIENT_PK env var with mnemonic");
+  }
+
+  const { address, key } = await deriveChildAccount(X402_NETWORK, X402_CLIENT_PK, 0);
+  const logger = createTestLogger("memory-lifecycle", verbose);
+  logger.info(`Test wallet address: ${address}`);
+
+  const x402Client = new X402PaymentClient({
+    network: X402_NETWORK,
+    privateKey: key,
+  });
+
+  // Test with STX only to save on payments
+  const tokenType: TokenType = "STX";
+  const testPrefix = generateTestId("mem");
+  const testItems = [
+    { id: `${testPrefix}-1`, text: "The quick brown fox jumps over the lazy dog." },
+    { id: `${testPrefix}-2`, text: "Artificial intelligence is transforming the world of technology." },
+    { id: `${testPrefix}-3`, text: "Bitcoin is a decentralized digital currency." },
+  ];
+
+  let successCount = 0;
+  const totalTests = 6;
+
+  // Test 1: Store items with embeddings
+  logger.info("1. Testing /storage/memory/store (POST)...");
+  const storeResult = await makeX402Request(
+    x402Client,
+    "/storage/memory/store",
+    "POST",
+    { items: testItems },
+    tokenType,
+    logger
+  );
+
+  const storeData = storeResult.data as { ok?: boolean; stored?: number };
+  if (storeResult.status === 200 && storeData.ok && storeData.stored === testItems.length) {
+    logger.success(`Stored ${storeData.stored} items with embeddings`);
+    successCount++;
+  } else {
+    logger.error(`Store failed: ${JSON.stringify(storeResult.data)}`);
+    logger.info("Bailing out: initial store failed, skipping remaining tests");
+    logger.summary(0, totalTests);
+    return { passed: 0, total: totalTests, success: false };
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 2: List items
+  logger.info("2. Testing /storage/memory/list (GET)...");
+  const listResult = await makeX402Request(
+    x402Client,
+    "/storage/memory/list",
+    "GET",
+    null,
+    tokenType,
+    logger
+  );
+
+  const listData = listResult.data as { ok?: boolean; items?: Array<{ id: string }>; total?: number };
+  if (listResult.status === 200 && listData.ok && Array.isArray(listData.items)) {
+    // Check if our test items are in the list
+    const foundItems = listData.items.filter((i) => i.id.startsWith(testPrefix));
+    if (foundItems.length >= testItems.length) {
+      logger.success(`List shows ${listData.total} total items, found ${foundItems.length} test items`);
+      successCount++;
+    } else {
+      logger.error(`List returned items but only found ${foundItems.length} of ${testItems.length} test items`);
+    }
+  } else {
+    logger.error(`List failed: ${JSON.stringify(listResult.data)}`);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 3: Search (semantic similarity)
+  logger.info("3. Testing /storage/memory/search (POST)...");
+  const searchResult = await makeX402Request(
+    x402Client,
+    "/storage/memory/search",
+    "POST",
+    { query: "cryptocurrency blockchain", limit: 5, threshold: 0.3 },
+    tokenType,
+    logger
+  );
+
+  const searchData = searchResult.data as { ok?: boolean; results?: Array<{ id: string; similarity: number }> };
+  if (searchResult.status === 200 && searchData.ok && Array.isArray(searchData.results)) {
+    // The Bitcoin-related item should have higher similarity
+    logger.success(`Search returned ${searchData.results.length} results`);
+    successCount++;
+  } else {
+    logger.error(`Search failed: ${JSON.stringify(searchResult.data)}`);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 4: Delete one item
+  logger.info("4. Testing /storage/memory/delete (POST)...");
+  const deleteResult = await makeX402Request(
+    x402Client,
+    "/storage/memory/delete",
+    "POST",
+    { ids: [testItems[0].id] },
+    tokenType,
+    logger
+  );
+
+  const deleteData = deleteResult.data as { ok?: boolean; deleted?: number };
+  if (deleteResult.status === 200 && deleteData.ok && deleteData.deleted === 1) {
+    logger.success(`Deleted 1 item`);
+    successCount++;
+  } else {
+    logger.error(`Delete failed: ${JSON.stringify(deleteResult.data)}`);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 5: Clear all remaining items
+  logger.info("5. Testing /storage/memory/clear (POST)...");
+  const clearResult = await makeX402Request(
+    x402Client,
+    "/storage/memory/clear",
+    "POST",
+    {},
+    tokenType,
+    logger
+  );
+
+  const clearData = clearResult.data as { ok?: boolean; cleared?: number };
+  if (clearResult.status === 200 && clearData.ok) {
+    logger.success(`Cleared memory (${clearData.cleared || 0} items removed)`);
+    successCount++;
+  } else {
+    logger.error(`Clear failed: ${JSON.stringify(clearResult.data)}`);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 6: Verify memory is empty
+  logger.info("6. Verifying memory is empty...");
+  const verifyResult = await makeX402Request(
+    x402Client,
+    "/storage/memory/list",
+    "GET",
+    null,
+    tokenType,
+    logger
+  );
+
+  const verifyData = verifyResult.data as { ok?: boolean; total?: number };
+  if (verifyResult.status === 200 && verifyData.ok && verifyData.total === 0) {
+    logger.success(`Memory is empty`);
+    successCount++;
+  } else {
+    logger.error(`Memory not empty after clear: ${JSON.stringify(verifyResult.data)}`);
+  }
+
+  logger.summary(successCount, totalTests);
+  return { passed: successCount, total: totalTests, success: successCount === totalTests };
+}
+
+// Run if executed directly
+if (import.meta.main) {
+  const verbose = process.argv.includes("-v") || process.argv.includes("--verbose");
+  runMemoryLifecycle(verbose)
+    .then((result) => process.exit(result.success ? 0 : 1))
+    .catch((err) => {
+      console.error("Test failed:", err);
+      process.exit(1);
+    });
+}

--- a/tests/paste-lifecycle.test.ts
+++ b/tests/paste-lifecycle.test.ts
@@ -1,0 +1,308 @@
+#!/usr/bin/env bun
+/**
+ * Paste Storage Lifecycle Test
+ *
+ * Tests the complete lifecycle of paste storage operations:
+ * 1. Create a paste
+ * 2. Get the paste back
+ * 3. Delete the paste
+ * 4. Verify deletion
+ */
+
+import type { TokenType } from "x402-stacks";
+import { X402PaymentClient } from "x402-stacks";
+import { deriveChildAccount } from "../src/utils/wallet";
+import {
+  X402_CLIENT_PK,
+  X402_NETWORK,
+  X402_WORKER_URL,
+  createTestLogger,
+  STEP_DELAY_MS,
+  generateTestId,
+  DEFAULT_MAX_RETRIES,
+  isRetryableError,
+  calculateBackoff,
+  sleep,
+  isTerminalStatus,
+  parseErrorResponse,
+  parseResponseData,
+} from "./_shared_utils";
+
+interface X402PaymentRequired {
+  maxAmountRequired: string;
+  resource: string;
+  payTo: string;
+  network: "mainnet" | "testnet";
+  nonce: string;
+  expiresAt: string;
+  tokenType: TokenType;
+}
+
+/** JSON-serializable body type */
+type JsonBody =
+  | Record<string, unknown>
+  | unknown[]
+  | string
+  | number
+  | boolean
+  | null;
+
+async function makeX402Request(
+  x402Client: X402PaymentClient,
+  endpoint: string,
+  method: "GET" | "POST" | "DELETE",
+  body: JsonBody | undefined,
+  tokenType: TokenType,
+  logger: ReturnType<typeof createTestLogger>,
+  maxRetries: number = DEFAULT_MAX_RETRIES
+): Promise<{ status: number; data: unknown }> {
+  const url = `${X402_WORKER_URL}${endpoint}?tokenType=${tokenType}`;
+
+  // Track last error for retry exhaustion reporting
+  let lastErrorStatus = 0;
+  let lastErrorData: unknown = "Failed to get payment requirement";
+
+  // Retry loop for initial request (get 402 payment requirement)
+  let initialRes: Response | null = null;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      initialRes = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      // 402 is expected - break to continue payment flow
+      if (initialRes.status === 402) break;
+
+      // Terminal status codes (200, 404) - return immediately
+      if (isTerminalStatus(initialRes.status)) {
+        const text = await initialRes.text();
+        return { status: initialRes.status, data: parseResponseData(text) };
+      }
+
+      // Parse error and check if retryable
+      const text = await initialRes.text();
+      const errorInfo = parseErrorResponse(text);
+      lastErrorStatus = initialRes.status;
+      lastErrorData = parseResponseData(text);
+
+      if (isRetryableError(initialRes.status, errorInfo.errorCode, errorInfo.errorMessage || text) && attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt, errorInfo.retryAfterSecs);
+        logger.debug(`Initial request failed (${initialRes.status}), retry ${attempt + 1}/${maxRetries} in ${delayMs}ms`);
+        await sleep(delayMs);
+        continue;
+      }
+
+      // Non-retryable error - return last captured error
+      return { status: lastErrorStatus, data: lastErrorData };
+    } catch (fetchError) {
+      lastErrorStatus = 0;
+      lastErrorData = { error: String(fetchError), code: "NETWORK_ERROR" };
+
+      if (attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt);
+        logger.debug(`Fetch error, retry ${attempt + 1}/${maxRetries} in ${delayMs}ms: ${fetchError}`);
+        await sleep(delayMs);
+        continue;
+      }
+      return { status: lastErrorStatus, data: lastErrorData };
+    }
+  }
+
+  // Check if we got a 402 payment requirement
+  if (!initialRes || initialRes.status !== 402) {
+    return { status: lastErrorStatus, data: lastErrorData };
+  }
+
+  const paymentReq: X402PaymentRequired = await initialRes.json();
+  logger.debug("402 Payment req", paymentReq);
+
+  const signResult = await x402Client.signPayment(paymentReq);
+  logger.debug("Signed payment", signResult);
+
+  // Reset error tracking for paid request phase
+  lastErrorStatus = 0;
+  lastErrorData = "Exhausted retries on paid request";
+
+  // Retry loop for paid request
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const retryRes = await fetch(url, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          "X-PAYMENT": signResult.signedTransaction,
+          "X-PAYMENT-TOKEN-TYPE": tokenType,
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      // Terminal status codes (200, 404) - return immediately
+      if (isTerminalStatus(retryRes.status)) {
+        const text = await retryRes.text();
+        return { status: retryRes.status, data: parseResponseData(text) };
+      }
+
+      // Parse error and check if retryable
+      const text = await retryRes.text();
+      const errorInfo = parseErrorResponse(text);
+      lastErrorStatus = retryRes.status;
+      lastErrorData = parseResponseData(text);
+
+      if (isRetryableError(retryRes.status, errorInfo.errorCode, errorInfo.errorMessage || text) && attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt, errorInfo.retryAfterSecs);
+        logger.debug(`Paid request failed (${retryRes.status}), retry ${attempt + 1}/${maxRetries} in ${delayMs}ms`);
+        await sleep(delayMs);
+        continue;
+      }
+
+      // Non-retryable error - return last captured error
+      return { status: lastErrorStatus, data: lastErrorData };
+    } catch (fetchError) {
+      lastErrorStatus = 0;
+      lastErrorData = { error: String(fetchError), code: "NETWORK_ERROR" };
+
+      if (attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt);
+        logger.debug(`Fetch error on paid request, retry ${attempt + 1}/${maxRetries} in ${delayMs}ms: ${fetchError}`);
+        await sleep(delayMs);
+        continue;
+      }
+      return { status: lastErrorStatus, data: lastErrorData };
+    }
+  }
+
+  // Exhausted retries - return last captured error
+  return { status: lastErrorStatus, data: lastErrorData };
+}
+
+export interface LifecycleTestResult {
+  passed: number;
+  total: number;
+  success: boolean;
+}
+
+export async function runPasteLifecycle(verbose = false): Promise<LifecycleTestResult> {
+  if (!X402_CLIENT_PK) {
+    throw new Error("Set X402_CLIENT_PK env var with mnemonic");
+  }
+
+  const { address, key } = await deriveChildAccount(X402_NETWORK, X402_CLIENT_PK, 0);
+  const logger = createTestLogger("paste-lifecycle", verbose);
+  logger.info(`Test wallet address: ${address}`);
+
+  const x402Client = new X402PaymentClient({
+    network: X402_NETWORK,
+    privateKey: key,
+  });
+
+  // Test with STX only to save on payments
+  const tokenType: TokenType = "STX";
+  const testContent = `Test paste content from lifecycle test - ${generateTestId("paste")}`;
+  const testTitle = "Test Paste";
+  const testLanguage = "text";
+
+  let successCount = 0;
+  const totalTests = 4;
+  let pasteId: string | null = null;
+
+  // Test 1: Create a paste
+  logger.info("1. Testing /storage/paste (POST - create)...");
+  const createResult = await makeX402Request(
+    x402Client,
+    "/storage/paste",
+    "POST",
+    { content: testContent, title: testTitle, language: testLanguage, ttl: 300 },
+    tokenType,
+    logger
+  );
+
+  const createData = createResult.data as { ok?: boolean; id?: string; createdAt?: string };
+  if (createResult.status === 200 && createData.ok && createData.id) {
+    pasteId = createData.id;
+    logger.success(`Created paste with id "${pasteId}"`);
+    successCount++;
+  } else {
+    logger.error(`Create failed: ${JSON.stringify(createResult.data)}`);
+    logger.info("Bailing out: initial create failed, skipping remaining tests");
+    logger.summary(0, totalTests);
+    return { passed: 0, total: totalTests, success: false };
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 2: Get the paste back
+  logger.info("2. Testing /storage/paste/:id (GET)...");
+  const getResult = await makeX402Request(
+    x402Client,
+    `/storage/paste/${pasteId}`,
+    "GET",
+    null,
+    tokenType,
+    logger
+  );
+
+  const getData = getResult.data as { ok?: boolean; content?: string; title?: string };
+  if (getResult.status === 200 && getData.ok && getData.content === testContent) {
+    logger.success(`Got paste back correctly`);
+    successCount++;
+  } else {
+    logger.error(`Get failed: ${JSON.stringify(getResult.data)}`);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 3: Delete the paste
+  logger.info("3. Testing /storage/paste/:id (DELETE)...");
+  const deleteResult = await makeX402Request(
+    x402Client,
+    `/storage/paste/${pasteId}`,
+    "DELETE",
+    null,
+    tokenType,
+    logger
+  );
+
+  const deleteData = deleteResult.data as { ok?: boolean; deleted?: boolean };
+  if (deleteResult.status === 200 && deleteData.ok) {
+    logger.success(`Deleted paste "${pasteId}"`);
+    successCount++;
+  } else {
+    logger.error(`Delete failed: ${JSON.stringify(deleteResult.data)}`);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 4: Verify deletion
+  logger.info("4. Verifying deletion...");
+  const verifyResult = await makeX402Request(
+    x402Client,
+    `/storage/paste/${pasteId}`,
+    "GET",
+    null,
+    tokenType,
+    logger
+  );
+
+  if (verifyResult.status === 404) {
+    logger.success(`Verified paste is deleted (404)`);
+    successCount++;
+  } else {
+    logger.error(`Paste still exists after delete: ${JSON.stringify(verifyResult.data)}`);
+  }
+
+  logger.summary(successCount, totalTests);
+  return { passed: successCount, total: totalTests, success: successCount === totalTests };
+}
+
+// Run if executed directly
+if (import.meta.main) {
+  const verbose = process.argv.includes("-v") || process.argv.includes("--verbose");
+  runPasteLifecycle(verbose)
+    .then((result) => process.exit(result.success ? 0 : 1))
+    .catch((err) => {
+      console.error("Test failed:", err);
+      process.exit(1);
+    });
+}

--- a/tests/queue-lifecycle.test.ts
+++ b/tests/queue-lifecycle.test.ts
@@ -1,0 +1,354 @@
+#!/usr/bin/env bun
+/**
+ * Queue Storage Lifecycle Test
+ *
+ * Tests the complete lifecycle of queue operations:
+ * 1. Push (add items to queue)
+ * 2. Status (check queue has items)
+ * 3. Peek (view items without removing)
+ * 4. Pop (remove and get items)
+ * 5. Clear (remove remaining items)
+ * 6. Status (verify queue is empty)
+ */
+
+import type { TokenType } from "x402-stacks";
+import { X402PaymentClient } from "x402-stacks";
+import { deriveChildAccount } from "../src/utils/wallet";
+import {
+  X402_CLIENT_PK,
+  X402_NETWORK,
+  X402_WORKER_URL,
+  createTestLogger,
+  STEP_DELAY_MS,
+  generateTestId,
+  DEFAULT_MAX_RETRIES,
+  isRetryableError,
+  calculateBackoff,
+  sleep,
+  isTerminalStatus,
+  parseErrorResponse,
+  parseResponseData,
+} from "./_shared_utils";
+
+interface X402PaymentRequired {
+  maxAmountRequired: string;
+  resource: string;
+  payTo: string;
+  network: "mainnet" | "testnet";
+  nonce: string;
+  expiresAt: string;
+  tokenType: TokenType;
+}
+
+/** JSON-serializable body type */
+type JsonBody =
+  | Record<string, unknown>
+  | unknown[]
+  | string
+  | number
+  | boolean
+  | null;
+
+async function makeX402Request(
+  x402Client: X402PaymentClient,
+  endpoint: string,
+  method: "GET" | "POST" | "DELETE",
+  body: JsonBody | undefined,
+  tokenType: TokenType,
+  logger: ReturnType<typeof createTestLogger>,
+  maxRetries: number = DEFAULT_MAX_RETRIES
+): Promise<{ status: number; data: unknown }> {
+  const url = `${X402_WORKER_URL}${endpoint}${endpoint.includes("?") ? "&" : "?"}tokenType=${tokenType}`;
+
+  // Track last error for retry exhaustion reporting
+  let lastErrorStatus = 0;
+  let lastErrorData: unknown = "Failed to get payment requirement";
+
+  // Retry loop for initial request (get 402 payment requirement)
+  let initialRes: Response | null = null;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      initialRes = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      // 402 is expected - break to continue payment flow
+      if (initialRes.status === 402) break;
+
+      // Terminal status codes (200, 404) - return immediately
+      if (isTerminalStatus(initialRes.status)) {
+        const text = await initialRes.text();
+        return { status: initialRes.status, data: parseResponseData(text) };
+      }
+
+      // Parse error and check if retryable
+      const text = await initialRes.text();
+      const errorInfo = parseErrorResponse(text);
+      lastErrorStatus = initialRes.status;
+      lastErrorData = parseResponseData(text);
+
+      if (isRetryableError(initialRes.status, errorInfo.errorCode, errorInfo.errorMessage || text) && attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt, errorInfo.retryAfterSecs);
+        logger.debug(`Initial request failed (${initialRes.status}), retry ${attempt + 1}/${maxRetries} in ${delayMs}ms`);
+        await sleep(delayMs);
+        continue;
+      }
+
+      // Non-retryable error - return last captured error
+      return { status: lastErrorStatus, data: lastErrorData };
+    } catch (fetchError) {
+      lastErrorStatus = 0;
+      lastErrorData = { error: String(fetchError), code: "NETWORK_ERROR" };
+
+      if (attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt);
+        logger.debug(`Fetch error, retry ${attempt + 1}/${maxRetries} in ${delayMs}ms: ${fetchError}`);
+        await sleep(delayMs);
+        continue;
+      }
+      return { status: lastErrorStatus, data: lastErrorData };
+    }
+  }
+
+  // Check if we got a 402 payment requirement
+  if (!initialRes || initialRes.status !== 402) {
+    return { status: lastErrorStatus, data: lastErrorData };
+  }
+
+  const paymentReq: X402PaymentRequired = await initialRes.json();
+  logger.debug("402 Payment req", paymentReq);
+
+  const signResult = await x402Client.signPayment(paymentReq);
+  logger.debug("Signed payment", signResult);
+
+  // Reset error tracking for paid request phase
+  lastErrorStatus = 0;
+  lastErrorData = "Exhausted retries on paid request";
+
+  // Retry loop for paid request
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const retryRes = await fetch(url, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          "X-PAYMENT": signResult.signedTransaction,
+          "X-PAYMENT-TOKEN-TYPE": tokenType,
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      // Terminal status codes (200, 404) - return immediately
+      if (isTerminalStatus(retryRes.status)) {
+        const text = await retryRes.text();
+        return { status: retryRes.status, data: parseResponseData(text) };
+      }
+
+      // Parse error and check if retryable
+      const text = await retryRes.text();
+      const errorInfo = parseErrorResponse(text);
+      lastErrorStatus = retryRes.status;
+      lastErrorData = parseResponseData(text);
+
+      if (isRetryableError(retryRes.status, errorInfo.errorCode, errorInfo.errorMessage || text) && attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt, errorInfo.retryAfterSecs);
+        logger.debug(`Paid request failed (${retryRes.status}), retry ${attempt + 1}/${maxRetries} in ${delayMs}ms`);
+        await sleep(delayMs);
+        continue;
+      }
+
+      // Non-retryable error - return last captured error
+      return { status: lastErrorStatus, data: lastErrorData };
+    } catch (fetchError) {
+      lastErrorStatus = 0;
+      lastErrorData = { error: String(fetchError), code: "NETWORK_ERROR" };
+
+      if (attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt);
+        logger.debug(`Fetch error on paid request, retry ${attempt + 1}/${maxRetries} in ${delayMs}ms: ${fetchError}`);
+        await sleep(delayMs);
+        continue;
+      }
+      return { status: lastErrorStatus, data: lastErrorData };
+    }
+  }
+
+  // Exhausted retries - return last captured error
+  return { status: lastErrorStatus, data: lastErrorData };
+}
+
+export interface LifecycleTestResult {
+  passed: number;
+  total: number;
+  success: boolean;
+}
+
+export async function runQueueLifecycle(verbose = false): Promise<LifecycleTestResult> {
+  if (!X402_CLIENT_PK) {
+    throw new Error("Set X402_CLIENT_PK env var with mnemonic");
+  }
+
+  const { address, key } = await deriveChildAccount(X402_NETWORK, X402_CLIENT_PK, 0);
+  const logger = createTestLogger("queue-lifecycle", verbose);
+  logger.info(`Test wallet address: ${address}`);
+
+  const x402Client = new X402PaymentClient({
+    network: X402_NETWORK,
+    privateKey: key,
+  });
+
+  // Test with STX only to save on payments
+  const tokenType: TokenType = "STX";
+  const queueName = generateTestId("queue");
+  const testItems = [
+    { task: "task1", data: "first item" },
+    { task: "task2", data: "second item" },
+    { task: "task3", data: "third item" },
+  ];
+
+  let successCount = 0;
+  const totalTests = 6;
+
+  // Test 1: Push items to queue
+  logger.info("1. Testing /storage/queue/push (POST)...");
+  const pushResult = await makeX402Request(
+    x402Client,
+    "/storage/queue/push",
+    "POST",
+    { name: queueName, items: testItems, priority: 0 },
+    tokenType,
+    logger
+  );
+
+  const pushData = pushResult.data as { ok?: boolean; pushed?: number };
+  if (pushResult.status === 200 && pushData.ok && pushData.pushed === testItems.length) {
+    logger.success(`Pushed ${pushData.pushed} items to queue "${queueName}"`);
+    successCount++;
+  } else {
+    logger.error(`Push failed: ${JSON.stringify(pushResult.data)}`);
+    logger.info("Bailing out: initial push failed, skipping remaining tests");
+    logger.summary(0, totalTests);
+    return { passed: 0, total: totalTests, success: false };
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 2: Check queue status
+  logger.info("2. Testing /storage/queue/status (GET)...");
+  const statusResult = await makeX402Request(
+    x402Client,
+    `/storage/queue/status?name=${queueName}`,
+    "GET",
+    null,
+    tokenType,
+    logger
+  );
+
+  const statusData = statusResult.data as { ok?: boolean; name?: string; pending?: number };
+  if (statusResult.status === 200 && statusData.ok && statusData.pending === testItems.length) {
+    logger.success(`Queue "${queueName}" has ${statusData.pending} pending items`);
+    successCount++;
+  } else {
+    logger.error(`Status check failed: ${JSON.stringify(statusResult.data)}`);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 3: Peek at items
+  logger.info("3. Testing /storage/queue/peek (GET)...");
+  const peekResult = await makeX402Request(
+    x402Client,
+    `/storage/queue/peek?name=${queueName}&count=2`,
+    "GET",
+    null,
+    tokenType,
+    logger
+  );
+
+  const peekData = peekResult.data as { ok?: boolean; items?: unknown[]; count?: number };
+  if (peekResult.status === 200 && peekData.ok && Array.isArray(peekData.items) && peekData.items.length === 2) {
+    logger.success(`Peeked at ${peekData.items.length} items (queue unchanged)`);
+    successCount++;
+  } else {
+    logger.error(`Peek failed: ${JSON.stringify(peekResult.data)}`);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 4: Pop one item
+  logger.info("4. Testing /storage/queue/pop (POST)...");
+  const popResult = await makeX402Request(
+    x402Client,
+    "/storage/queue/pop",
+    "POST",
+    { name: queueName, count: 1 },
+    tokenType,
+    logger
+  );
+
+  const popData = popResult.data as { ok?: boolean; items?: unknown[]; count?: number };
+  if (popResult.status === 200 && popData.ok && Array.isArray(popData.items) && popData.items.length === 1) {
+    logger.success(`Popped ${popData.items.length} item from queue`);
+    successCount++;
+  } else {
+    logger.error(`Pop failed: ${JSON.stringify(popResult.data)}`);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 5: Clear remaining items
+  logger.info("5. Testing /storage/queue/clear (POST)...");
+  const clearResult = await makeX402Request(
+    x402Client,
+    "/storage/queue/clear",
+    "POST",
+    { name: queueName },
+    tokenType,
+    logger
+  );
+
+  const clearData = clearResult.data as { ok?: boolean; cleared?: number };
+  if (clearResult.status === 200 && clearData.ok) {
+    logger.success(`Cleared queue "${queueName}" (${clearData.cleared || 0} items removed)`);
+    successCount++;
+  } else {
+    logger.error(`Clear failed: ${JSON.stringify(clearResult.data)}`);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 6: Verify queue is empty
+  logger.info("6. Verifying queue is empty...");
+  const verifyResult = await makeX402Request(
+    x402Client,
+    `/storage/queue/status?name=${queueName}`,
+    "GET",
+    null,
+    tokenType,
+    logger
+  );
+
+  const verifyData = verifyResult.data as { ok?: boolean; pending?: number };
+  if (verifyResult.status === 200 && verifyData.ok && verifyData.pending === 0) {
+    logger.success(`Queue "${queueName}" is empty`);
+    successCount++;
+  } else {
+    logger.error(`Queue not empty after clear: ${JSON.stringify(verifyResult.data)}`);
+  }
+
+  logger.summary(successCount, totalTests);
+  return { passed: successCount, total: totalTests, success: successCount === totalTests };
+}
+
+// Run if executed directly
+if (import.meta.main) {
+  const verbose = process.argv.includes("-v") || process.argv.includes("--verbose");
+  runQueueLifecycle(verbose)
+    .then((result) => process.exit(result.success ? 0 : 1))
+    .catch((err) => {
+      console.error("Test failed:", err);
+      process.exit(1);
+    });
+}

--- a/tests/sync-lifecycle.test.ts
+++ b/tests/sync-lifecycle.test.ts
@@ -1,0 +1,356 @@
+#!/usr/bin/env bun
+/**
+ * Sync (Distributed Lock) Lifecycle Test
+ *
+ * Tests the complete lifecycle of distributed lock operations:
+ * 1. Lock (acquire a lock)
+ * 2. Status (verify lock is held)
+ * 3. List (verify lock appears in list)
+ * 4. Extend (extend lock TTL)
+ * 5. Unlock (release the lock)
+ * 6. Verify unlock via status
+ */
+
+import type { TokenType } from "x402-stacks";
+import { X402PaymentClient } from "x402-stacks";
+import { deriveChildAccount } from "../src/utils/wallet";
+import {
+  X402_CLIENT_PK,
+  X402_NETWORK,
+  X402_WORKER_URL,
+  createTestLogger,
+  STEP_DELAY_MS,
+  generateTestId,
+  DEFAULT_MAX_RETRIES,
+  isRetryableError,
+  calculateBackoff,
+  sleep,
+  isTerminalStatus,
+  parseErrorResponse,
+  parseResponseData,
+} from "./_shared_utils";
+
+interface X402PaymentRequired {
+  maxAmountRequired: string;
+  resource: string;
+  payTo: string;
+  network: "mainnet" | "testnet";
+  nonce: string;
+  expiresAt: string;
+  tokenType: TokenType;
+}
+
+/** JSON-serializable body type */
+type JsonBody =
+  | Record<string, unknown>
+  | unknown[]
+  | string
+  | number
+  | boolean
+  | null;
+
+async function makeX402Request(
+  x402Client: X402PaymentClient,
+  endpoint: string,
+  method: "GET" | "POST" | "DELETE",
+  body: JsonBody | undefined,
+  tokenType: TokenType,
+  logger: ReturnType<typeof createTestLogger>,
+  maxRetries: number = DEFAULT_MAX_RETRIES
+): Promise<{ status: number; data: unknown }> {
+  const url = `${X402_WORKER_URL}${endpoint}?tokenType=${tokenType}`;
+
+  // Track last error for retry exhaustion reporting
+  let lastErrorStatus = 0;
+  let lastErrorData: unknown = "Failed to get payment requirement";
+
+  // Retry loop for initial request (get 402 payment requirement)
+  let initialRes: Response | null = null;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      initialRes = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      // 402 is expected - break to continue payment flow
+      if (initialRes.status === 402) break;
+
+      // Terminal status codes (200, 404) - return immediately
+      if (isTerminalStatus(initialRes.status)) {
+        const text = await initialRes.text();
+        return { status: initialRes.status, data: parseResponseData(text) };
+      }
+
+      // Parse error and check if retryable
+      const text = await initialRes.text();
+      const errorInfo = parseErrorResponse(text);
+      lastErrorStatus = initialRes.status;
+      lastErrorData = parseResponseData(text);
+
+      if (isRetryableError(initialRes.status, errorInfo.errorCode, errorInfo.errorMessage || text) && attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt, errorInfo.retryAfterSecs);
+        logger.debug(`Initial request failed (${initialRes.status}), retry ${attempt + 1}/${maxRetries} in ${delayMs}ms`);
+        await sleep(delayMs);
+        continue;
+      }
+
+      // Non-retryable error - return last captured error
+      return { status: lastErrorStatus, data: lastErrorData };
+    } catch (fetchError) {
+      lastErrorStatus = 0;
+      lastErrorData = { error: String(fetchError), code: "NETWORK_ERROR" };
+
+      if (attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt);
+        logger.debug(`Fetch error, retry ${attempt + 1}/${maxRetries} in ${delayMs}ms: ${fetchError}`);
+        await sleep(delayMs);
+        continue;
+      }
+      return { status: lastErrorStatus, data: lastErrorData };
+    }
+  }
+
+  // Check if we got a 402 payment requirement
+  if (!initialRes || initialRes.status !== 402) {
+    return { status: lastErrorStatus, data: lastErrorData };
+  }
+
+  const paymentReq: X402PaymentRequired = await initialRes.json();
+  logger.debug("402 Payment req", paymentReq);
+
+  const signResult = await x402Client.signPayment(paymentReq);
+  logger.debug("Signed payment", signResult);
+
+  // Reset error tracking for paid request phase
+  lastErrorStatus = 0;
+  lastErrorData = "Exhausted retries on paid request";
+
+  // Retry loop for paid request
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const retryRes = await fetch(url, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          "X-PAYMENT": signResult.signedTransaction,
+          "X-PAYMENT-TOKEN-TYPE": tokenType,
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      // Terminal status codes (200, 404) - return immediately
+      if (isTerminalStatus(retryRes.status)) {
+        const text = await retryRes.text();
+        return { status: retryRes.status, data: parseResponseData(text) };
+      }
+
+      // Parse error and check if retryable
+      const text = await retryRes.text();
+      const errorInfo = parseErrorResponse(text);
+      lastErrorStatus = retryRes.status;
+      lastErrorData = parseResponseData(text);
+
+      if (isRetryableError(retryRes.status, errorInfo.errorCode, errorInfo.errorMessage || text) && attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt, errorInfo.retryAfterSecs);
+        logger.debug(`Paid request failed (${retryRes.status}), retry ${attempt + 1}/${maxRetries} in ${delayMs}ms`);
+        await sleep(delayMs);
+        continue;
+      }
+
+      // Non-retryable error - return last captured error
+      return { status: lastErrorStatus, data: lastErrorData };
+    } catch (fetchError) {
+      lastErrorStatus = 0;
+      lastErrorData = { error: String(fetchError), code: "NETWORK_ERROR" };
+
+      if (attempt < maxRetries) {
+        const delayMs = calculateBackoff(attempt);
+        logger.debug(`Fetch error on paid request, retry ${attempt + 1}/${maxRetries} in ${delayMs}ms: ${fetchError}`);
+        await sleep(delayMs);
+        continue;
+      }
+      return { status: lastErrorStatus, data: lastErrorData };
+    }
+  }
+
+  // Exhausted retries - return last captured error
+  return { status: lastErrorStatus, data: lastErrorData };
+}
+
+export interface LifecycleTestResult {
+  passed: number;
+  total: number;
+  success: boolean;
+}
+
+export async function runSyncLifecycle(verbose = false): Promise<LifecycleTestResult> {
+  if (!X402_CLIENT_PK) {
+    throw new Error("Set X402_CLIENT_PK env var with mnemonic");
+  }
+
+  const { address, key } = await deriveChildAccount(X402_NETWORK, X402_CLIENT_PK, 0);
+  const logger = createTestLogger("sync-lifecycle", verbose);
+  logger.info(`Test wallet address: ${address}`);
+
+  const x402Client = new X402PaymentClient({
+    network: X402_NETWORK,
+    privateKey: key,
+  });
+
+  // Test with STX only to save on payments
+  const tokenType: TokenType = "STX";
+  const lockName = generateTestId("lock");
+
+  let successCount = 0;
+  const totalTests = 6;
+  let lockToken: string | null = null;
+
+  // Test 1: Acquire lock
+  logger.info("1. Testing /storage/sync/lock (POST - acquire)...");
+  const lockResult = await makeX402Request(
+    x402Client,
+    "/storage/sync/lock",
+    "POST",
+    { name: lockName, ttl: 60 },
+    tokenType,
+    logger
+  );
+
+  const lockData = lockResult.data as { ok?: boolean; acquired?: boolean; token?: string; name?: string };
+  if (lockResult.status === 200 && lockData.ok && lockData.acquired && lockData.token) {
+    lockToken = lockData.token;
+    logger.success(`Acquired lock "${lockName}" with token`);
+    successCount++;
+  } else {
+    logger.error(`Lock acquire failed: ${JSON.stringify(lockResult.data)}`);
+    logger.info("Bailing out: initial lock failed, skipping remaining tests");
+    logger.summary(0, totalTests);
+    return { passed: 0, total: totalTests, success: false };
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 2: Check status
+  logger.info("2. Testing /storage/sync/status/:name (GET)...");
+  const statusResult = await makeX402Request(
+    x402Client,
+    `/storage/sync/status/${lockName}`,
+    "GET",
+    null,
+    tokenType,
+    logger
+  );
+
+  const statusData = statusResult.data as { ok?: boolean; locked?: boolean; name?: string };
+  if (statusResult.status === 200 && statusData.ok && statusData.locked === true) {
+    logger.success(`Status shows lock "${lockName}" is held`);
+    successCount++;
+  } else {
+    logger.error(`Status check failed: ${JSON.stringify(statusResult.data)}`);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 3: List locks
+  logger.info("3. Testing /storage/sync/list (GET)...");
+  const listResult = await makeX402Request(
+    x402Client,
+    "/storage/sync/list",
+    "GET",
+    null,
+    tokenType,
+    logger
+  );
+
+  const listData = listResult.data as { ok?: boolean; locks?: Array<{ name: string }>; count?: number };
+  if (listResult.status === 200 && listData.ok && Array.isArray(listData.locks)) {
+    const foundLock = listData.locks.find((l) => l.name === lockName);
+    if (foundLock) {
+      logger.success(`List shows ${listData.count} lock(s), found test lock`);
+      successCount++;
+    } else {
+      logger.error(`List returned locks but test lock not found`);
+    }
+  } else {
+    logger.error(`List failed: ${JSON.stringify(listResult.data)}`);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 4: Extend lock
+  logger.info("4. Testing /storage/sync/extend (POST)...");
+  const extendResult = await makeX402Request(
+    x402Client,
+    "/storage/sync/extend",
+    "POST",
+    { name: lockName, token: lockToken, ttl: 120 },
+    tokenType,
+    logger
+  );
+
+  const extendData = extendResult.data as { ok?: boolean; extended?: boolean; name?: string };
+  if (extendResult.status === 200 && extendData.ok && extendData.extended) {
+    logger.success(`Extended lock "${lockName}" TTL`);
+    successCount++;
+  } else {
+    logger.error(`Extend failed: ${JSON.stringify(extendResult.data)}`);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 5: Release lock
+  logger.info("5. Testing /storage/sync/unlock (POST)...");
+  const unlockResult = await makeX402Request(
+    x402Client,
+    "/storage/sync/unlock",
+    "POST",
+    { name: lockName, token: lockToken },
+    tokenType,
+    logger
+  );
+
+  const unlockData = unlockResult.data as { ok?: boolean; released?: boolean; name?: string };
+  if (unlockResult.status === 200 && unlockData.ok && unlockData.released) {
+    logger.success(`Released lock "${lockName}"`);
+    successCount++;
+  } else {
+    logger.error(`Unlock failed: ${JSON.stringify(unlockResult.data)}`);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, STEP_DELAY_MS));
+
+  // Test 6: Verify unlock via status
+  logger.info("6. Verifying unlock via status...");
+  const verifyResult = await makeX402Request(
+    x402Client,
+    `/storage/sync/status/${lockName}`,
+    "GET",
+    null,
+    tokenType,
+    logger
+  );
+
+  const verifyData = verifyResult.data as { ok?: boolean; locked?: boolean };
+  if (verifyResult.status === 200 && verifyData.ok && verifyData.locked === false) {
+    logger.success(`Verified lock "${lockName}" is released`);
+    successCount++;
+  } else {
+    logger.error(`Lock still held after unlock: ${JSON.stringify(verifyResult.data)}`);
+  }
+
+  logger.summary(successCount, totalTests);
+  return { passed: successCount, total: totalTests, success: successCount === totalTests };
+}
+
+// Run if executed directly
+if (import.meta.main) {
+  const verbose = process.argv.includes("-v") || process.argv.includes("--verbose");
+  runSyncLifecycle(verbose)
+    .then((result) => process.exit(result.success ? 0 : 1))
+    .catch((err) => {
+      console.error("Test failed:", err);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary
- Add lifecycle tests for paste, db, sync, queue, and memory storage categories
- Each test covers the full CRUD lifecycle with proper cleanup
- Update dashboard to display testnet/mainnet instead of staging/production

## Test Coverage

| Category | Tests | Steps |
|----------|-------|-------|
| paste | 4 | Create → Get → Delete → Verify deletion |
| db | 5 | Create table → Insert → Query → Schema → Drop table |
| sync | 6 | Lock → Status → List → Extend → Unlock → Verify unlock |
| queue | 6 | Push → Status → Peek → Pop → Clear → Verify empty |
| memory | 6 | Store → List → Search → Delete → Clear → Verify empty |

## Test plan
- [x] All lifecycle tests pass locally
- [x] Type check passes (`npm run check`)
- [x] Full test suite passes (`npm run test:full`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)