### PR TITLE
feat: add LOGS service binding for centralized logging

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -33,6 +33,9 @@
       { "name": "METRICS_DO", "class_name": "MetricsDO" }
     ]
   },
+  "services": [
+    { "binding": "LOGS", "service": "worker-logs-staging", "entrypoint": "LogsRPC" }
+  ],
   "migrations": [
     { "tag": "v1", "new_sqlite_classes": ["UsageDO", "StorageDO"] },
     { "tag": "v2", "new_sqlite_classes": ["MetricsDO"] }
@@ -77,7 +80,10 @@
           { "name": "STORAGE_DO", "class_name": "StorageDO" },
           { "name": "METRICS_DO", "class_name": "MetricsDO" }
         ]
-      }
+      },
+      "services": [
+        { "binding": "LOGS", "service": "worker-logs-staging", "entrypoint": "LogsRPC" }
+      ]
     },
     "production": {
       "name": "x402-api-production",
@@ -102,7 +108,10 @@
           { "name": "STORAGE_DO", "class_name": "StorageDO" },
           { "name": "METRICS_DO", "class_name": "MetricsDO" }
         ]
-      }
+      },
+      "services": [
+        { "binding": "LOGS", "service": "worker-logs-production", "entrypoint": "LogsRPC" }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add worker-logs service bindings to enable centralized logging
- Local dev: worker-logs-staging  
- Staging env: worker-logs-staging
- Production env: worker-logs-production

The logger implementation was already in place but the binding was missing, causing it to fall back to console logging.

## Test plan
- [ ] Deploy to staging and verify logs appear in logs.aibtc.dev
- [ ] Deploy to production and verify logs appear in logs.aibtc.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)