### PR TITLE
chore: add logs directory to gitignore for cron test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
+# Logs
+logs/
+logs/test-runs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+.pnpm-debug.log*
+
 # Dependencies
 node_modules/
 


### PR DESCRIPTION
## Summary
- Add `logs/` and `logs/test-runs/` to gitignore for cron test runner output
- Add common log file patterns (`*.log`, `npm-debug.log*`, etc.) to match stx402 repo

## Test plan
- [x] Verified cron script runs successfully
- [x] Verified logs directory is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)