### PR TITLE
fix(tests): add retry logic for nonce conflict errors

### DIFF
--- a/tests/_run_all_tests.ts
+++ b/tests/_run_all_tests.ts
@@ -375,8 +375,8 @@ async function testEndpointWithToken(
         continue;
       }
 
-      // Check for other retryable errors
-      if (isRetryableError(retryRes.status, errorCode, errorMessage || errText) && attempt < maxRetries) {
+      // Check for other retryable errors (mutually exclusive with nonce conflict)
+      if (!isNonceConflict(fullErrorText) && isRetryableError(retryRes.status, errorCode, errorMessage || errText) && attempt < maxRetries) {
         const retryAfterSecs = retryAfterHeader ? parseInt(retryAfterHeader, 10) : bodyRetryAfter || 0;
         const delayMs = calculateBackoff(attempt, retryAfterSecs);
 

--- a/tests/db-lifecycle.test.ts
+++ b/tests/db-lifecycle.test.ts
@@ -44,7 +44,7 @@ async function makeX402Request(
   logger.debug(`Requesting ${method} ${endpoint}...`);
 
   const result = await makeX402RequestWithRetry(endpoint, method, x402Client, tokenType, {
-    body: body ?? undefined,
+    body,
     retry: {
       maxRetries: 3,
       nonceConflictDelayMs: NONCE_CONFLICT_DELAY_MS,
@@ -52,7 +52,7 @@ async function makeX402Request(
     },
   });
 
-  if (result.wasNonceConflict && result.retryCount && result.retryCount > 0) {
+  if (result.wasNonceConflict && result.retryCount > 0) {
     logger.debug(`Recovered from nonce conflict after ${result.retryCount} retries`);
   }
 

--- a/tests/inference-lifecycle.test.ts
+++ b/tests/inference-lifecycle.test.ts
@@ -155,7 +155,7 @@ async function makeX402Request(
     },
   });
 
-  if (result.wasNonceConflict && result.retryCount && result.retryCount > 0) {
+  if (result.wasNonceConflict && result.retryCount > 0) {
     logger.debug(`Recovered from nonce conflict after ${result.retryCount} retries`);
   }
 

--- a/tests/kv-lifecycle.test.ts
+++ b/tests/kv-lifecycle.test.ts
@@ -44,7 +44,7 @@ async function makeX402Request(
   logger.debug(`Requesting ${method} ${endpoint}...`);
 
   const result = await makeX402RequestWithRetry(endpoint, method, x402Client, tokenType, {
-    body: body ?? undefined,
+    body,
     retry: {
       maxRetries: 3,
       nonceConflictDelayMs: NONCE_CONFLICT_DELAY_MS,
@@ -52,7 +52,7 @@ async function makeX402Request(
     },
   });
 
-  if (result.wasNonceConflict && result.retryCount && result.retryCount > 0) {
+  if (result.wasNonceConflict && result.retryCount > 0) {
     logger.debug(`Recovered from nonce conflict after ${result.retryCount} retries`);
   }
 

--- a/tests/memory-lifecycle.test.ts
+++ b/tests/memory-lifecycle.test.ts
@@ -45,7 +45,7 @@ async function makeX402Request(
   logger.debug(`Requesting ${method} ${endpoint}...`);
 
   const result = await makeX402RequestWithRetry(endpoint, method, x402Client, tokenType, {
-    body: body ?? undefined,
+    body,
     retry: {
       maxRetries: 3,
       nonceConflictDelayMs: NONCE_CONFLICT_DELAY_MS,
@@ -53,7 +53,7 @@ async function makeX402Request(
     },
   });
 
-  if (result.wasNonceConflict && result.retryCount && result.retryCount > 0) {
+  if (result.wasNonceConflict && result.retryCount > 0) {
     logger.debug(`Recovered from nonce conflict after ${result.retryCount} retries`);
   }
 

--- a/tests/paste-lifecycle.test.ts
+++ b/tests/paste-lifecycle.test.ts
@@ -43,7 +43,7 @@ async function makeX402Request(
   logger.debug(`Requesting ${method} ${endpoint}...`);
 
   const result = await makeX402RequestWithRetry(endpoint, method, x402Client, tokenType, {
-    body: body ?? undefined,
+    body,
     retry: {
       maxRetries: 3,
       nonceConflictDelayMs: NONCE_CONFLICT_DELAY_MS,
@@ -51,7 +51,7 @@ async function makeX402Request(
     },
   });
 
-  if (result.wasNonceConflict && result.retryCount && result.retryCount > 0) {
+  if (result.wasNonceConflict && result.retryCount > 0) {
     logger.debug(`Recovered from nonce conflict after ${result.retryCount} retries`);
   }
 

--- a/tests/queue-lifecycle.test.ts
+++ b/tests/queue-lifecycle.test.ts
@@ -45,7 +45,7 @@ async function makeX402Request(
   logger.debug(`Requesting ${method} ${endpoint}...`);
 
   const result = await makeX402RequestWithRetry(endpoint, method, x402Client, tokenType, {
-    body: body ?? undefined,
+    body,
     retry: {
       maxRetries: 3,
       nonceConflictDelayMs: NONCE_CONFLICT_DELAY_MS,
@@ -53,7 +53,7 @@ async function makeX402Request(
     },
   });
 
-  if (result.wasNonceConflict && result.retryCount && result.retryCount > 0) {
+  if (result.wasNonceConflict && result.retryCount > 0) {
     logger.debug(`Recovered from nonce conflict after ${result.retryCount} retries`);
   }
 

--- a/tests/sync-lifecycle.test.ts
+++ b/tests/sync-lifecycle.test.ts
@@ -45,7 +45,7 @@ async function makeX402Request(
   logger.debug(`Requesting ${method} ${endpoint}...`);
 
   const result = await makeX402RequestWithRetry(endpoint, method, x402Client, tokenType, {
-    body: body ?? undefined,
+    body,
     retry: {
       maxRetries: 3,
       nonceConflictDelayMs: NONCE_CONFLICT_DELAY_MS,
@@ -53,7 +53,7 @@ async function makeX402Request(
     },
   });
 
-  if (result.wasNonceConflict && result.retryCount && result.retryCount > 0) {
+  if (result.wasNonceConflict && result.retryCount > 0) {
     logger.debug(`Recovered from nonce conflict after ${result.retryCount} retries`);
   }
 


### PR DESCRIPTION
## Summary

- Add smart retry handling for `ConflictingNonceInMempool` errors from the facilitator
- When nonce conflict detected: wait 30s, re-fetch 402, re-sign with fresh nonce, retry up to 3x
- Consolidate retry logic from 7 lifecycle tests into shared `makeX402RequestWithRetry()` helper

Ported from whoabuddy/stx402#21.

## Test plan

- [ ] Run `npm run check` to verify no type errors
- [ ] Run test suite locally to verify no regressions
- [ ] Monitor cron run logs for nonce conflict recovery messages

🤖 Generated with [Claude Code](https://claude.ai/code)