### PR TITLE
ci: add release-please for automated releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: node


### PR DESCRIPTION
## Summary
- Add release-please GitHub Action for automated semantic versioning
- Triggers on pushes to main, creates Release PRs automatically
- Uses `node` release-type to update `package.json` version

## Setup Required
After merging, the workflow needs permission to create PRs. See options below.

## Test plan
- [ ] Merge this PR
- [ ] Verify workflow runs on push to main
- [ ] Check that release-please creates a Release PR after next `feat:` or `fix:` commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)