### PR TITLE
feat(x402): implement V2 discovery manifest

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -446,13 +446,10 @@ app.get("/health", (c) => {
 
 // x402 discovery manifest (V2 protocol)
 app.get("/x402.json", (c) => {
-  const baseUrl = new URL(c.req.url).origin;
   const manifest = generateX402Manifest({
     network: c.env.X402_NETWORK === "mainnet" ? "mainnet" : "testnet",
     payTo: c.env.X402_SERVER_ADDRESS || "",
-    baseUrl,
-    serviceName: "x402 Stacks API",
-    serviceUrl: baseUrl,
+    baseUrl: new URL(c.req.url).origin,
   });
   return c.json(manifest);
 });


### PR DESCRIPTION
## Summary

- Rewrite `/x402.json` to emit V2-compliant manifest with CAIP-2 network IDs (`stacks:1` / `stacks:2147483648`), per-endpoint resource objects, `amount` field (replacing `maxAmountRequired`), and `service` metadata wrapper
- Move Bazaar metadata into `extensions.bazaar` per-endpoint with proper nesting
- Simplify generator by removing dead types, unused imports, and unnecessary config indirection

Closes #40

## Test plan

- [ ] `npm run check` passes (type check)
- [ ] `npm run deploy:dry-run` succeeds (build)
- [ ] Deploy to staging and fetch `https://x402.aibtc.dev/x402.json`
- [ ] Submit manifest to x402lint.com — zero errors
- [ ] Verify 402 payment flow still works (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)