### PR TITLE
fix: code hardening from stx402#39 learnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,13 @@
         "@stacks/encryption": "^7.3.1",
         "@stacks/network": "^7.3.1",
         "@stacks/transactions": "^7.3.1",
-        "@stacks/wallet-sdk": "^7.2.0",
         "chanfana": "^3.0.0",
         "hono": "^4.11.3",
         "x402-stacks": "^2.0.1"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260109.0",
+        "@stacks/wallet-sdk": "^7.2.0",
         "@types/bun": "^1.2.0",
         "patch-package": "^8.0.1",
         "typescript": "^5.9.3",
@@ -1193,6 +1193,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.3.tgz",
       "integrity": "sha512-dSH3+LCWONlSNQuF34xZrG6Xas7tp2jSSqHb/pMfXWM0vKE4JZOtK3uJfoWouUVW5IGlls75HkXmYLldZ8ySgQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1246,6 +1247,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/@stacks/auth/-/auth-7.3.1.tgz",
       "integrity": "sha512-8zjQrnthhymJruSWYuP17IRx+c0k8LrOZYH9DRyaTzjEZ+pbvsRUM9v7hH1aGr2LG94BI9249qXpCtGWorVI+g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/secp256k1": "1.7.1",
@@ -1293,6 +1295,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/@stacks/profile/-/profile-7.3.1.tgz",
       "integrity": "sha512-fjysyN29e0mZYN3PHkZAE+6w3cfWInamDYmKLLi+wTIw0ds4YRk0CaPnMHlanVybqdIQ84yeghETNL/+o+QxEQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@stacks/common": "^7.3.1",
@@ -1307,6 +1310,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/@stacks/storage/-/storage-7.3.1.tgz",
       "integrity": "sha512-AvbZJkc97LZ0icpIWeZpUgtSQS3Nsd3M16GYAJcHDqsBdsCtlwoSzsEwrcwrxZ1CFsWMnz3Te9xCNqUjoQ+CcA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@stacks/auth": "^7.3.1",
@@ -1335,6 +1339,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@stacks/wallet-sdk/-/wallet-sdk-7.2.0.tgz",
       "integrity": "sha512-w4UmIaulB03ki0eosWA2ju4vXtF1N+n+nX+/GuV8ZW3rbZ7xeRCv16IzZZL6TspMcaUKyZKTVB2uximqBNbqPQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@scure/bip32": "1.1.3",
@@ -1412,6 +1417,7 @@
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
       "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
@@ -2199,6 +2205,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
       "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.2",
@@ -2230,6 +2237,7 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
@@ -2474,6 +2482,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/schema-inspector/-/schema-inspector-2.1.0.tgz",
       "integrity": "sha512-3bmQVhbA01/EW8cZin4vIpqlpNU2SIy4BhKCfCgogJ3T/L76dLx3QAE+++4o+dNT33sa+SN9vOJL7iHiHFjiNg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "async": "~2.6.3"
@@ -2913,6 +2922,7 @@
       "version": "2.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/zone-file/-/zone-file-2.0.0-beta.3.tgz",
       "integrity": "sha512-6tE3PSRcpN5lbTTLlkLez40WkNPc9vw/u1J2j6DBiy0jcVX48nCkWrx2EC+bWHqC2SLp069Xw4AdnYn/qp/W5g==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260109.0",
+    "@stacks/wallet-sdk": "^7.2.0",
     "@types/bun": "^1.2.0",
     "patch-package": "^8.0.1",
     "typescript": "^5.9.3",
@@ -30,7 +31,6 @@
     "@stacks/encryption": "^7.3.1",
     "@stacks/network": "^7.3.1",
     "@stacks/transactions": "^7.3.1",
-    "@stacks/wallet-sdk": "^7.2.0",
     "chanfana": "^3.0.0",
     "hono": "^4.11.3",
     "x402-stacks": "^2.0.1"

--- a/src/endpoints/storage/memory/search.ts
+++ b/src/endpoints/storage/memory/search.ts
@@ -51,7 +51,7 @@ export class MemorySearch extends StorageReadEndpoint {
       const result = await env.AI.run("@cf/baai/bge-base-en-v1.5", { text: [query] }) as { data: number[][] };
       queryEmbedding = result.data[0];
     } catch (err) {
-      return this.errorResponse(c, `Embedding generation failed: ${err}`, 500);
+      return this.errorResponse(c, `Embedding generation failed: ${String(err)}`, 500);
     }
 
     const result = await storageDO.memorySearch(queryEmbedding, { limit, threshold }) as {

--- a/src/endpoints/storage/memory/store.ts
+++ b/src/endpoints/storage/memory/store.ts
@@ -72,7 +72,7 @@ export class MemoryStore extends StorageWriteLargeEndpoint {
       const result = await env.AI.run("@cf/baai/bge-base-en-v1.5", { text: texts }) as { data: number[][] };
       embeddings = result.data;
     } catch (err) {
-      return this.errorResponse(c, `Embedding generation failed: ${err}`, 500);
+      return this.errorResponse(c, `Embedding generation failed: ${String(err)}`, 500);
     }
 
     // Store items with embeddings

--- a/src/services/hiro.ts
+++ b/src/services/hiro.ts
@@ -65,14 +65,6 @@ export interface BnsName {
   owner: string;
 }
 
-export interface ContractInfo {
-  contract_id: string;
-  source_code: string;
-  abi: unknown;
-  block_height: number;
-  clarity_version: number;
-}
-
 export interface Transaction {
   tx_id: string;
   nonce: number;
@@ -227,26 +219,6 @@ export class HiroClient {
 
     const data = (await response.json()) as BnsName;
     return { address: data.owner };
-  }
-
-  /**
-   * Get contract info
-   */
-  async getContractInfo(contractId: string): Promise<ContractInfo> {
-    this.log.debug("Fetching contract info", { contractId });
-
-    const response = await fetch(
-      `${this.baseUrl}/v2/contracts/source/${contractId}`,
-      { headers: this.getHeaders() }
-    );
-
-    if (!response.ok) {
-      const error = await response.text();
-      this.log.error("Failed to fetch contract info", { contractId, error });
-      throw new HiroError(`Failed to fetch contract: ${response.status}`, response.status);
-    }
-
-    return response.json() as Promise<ContractInfo>;
   }
 
   /**

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "x402-api",
   "main": "src/index.ts",
+  "minify": true,
   "compatibility_date": "2025-01-08",
   "compatibility_flags": ["nodejs_compat_v2"],
   // Local development settings


### PR DESCRIPTION
## Summary

Applies cleanup learnings from whoabuddy/stx402#39 to our codebase:

- **Move `@stacks/wallet-sdk` to devDependencies** — only used in test files via `src/utils/wallet.ts`
- **Fix `${err}` → `String(err)`** — safe error serialization in `memory/store.ts` and `memory/search.ts`
- **Remove dead code** — `HiroClient.getContractInfo()` and `ContractInfo` type (zero call sites)
- **Enable `"minify": true`** in `wrangler.jsonc` for smaller production bundles

## Test plan

- [x] `tsc --noEmit` passes
- [x] `wrangler deploy --dry-run` passes (935 KiB upload, gzip: 246 KiB)
- [ ] Run `npm test` against local dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)