### PR TITLE
fix: guard estimateInputTokens against non-iterable input

### DIFF
--- a/src/middleware/x402.ts
+++ b/src/middleware/x402.ts
@@ -238,6 +238,11 @@ export function x402Middleware(
           return c.json({ error: "Missing or invalid 'model' field", code: "invalid_request" }, 400);
         }
 
+        // Validate messages field before estimateInputTokens iterates over it
+        if (!Array.isArray(chatRequest.messages)) {
+          return c.json({ error: "Missing or invalid 'messages' field: must be an array", code: "invalid_request" }, 400);
+        }
+
         // Pre-payment model validation: reject unknown models before issuing 402
         if (c.env.OPENROUTER_API_KEY) {
           const modelResult = await lookupModel(chatRequest.model, c.env.OPENROUTER_API_KEY, log);

--- a/src/services/pricing.ts
+++ b/src/services/pricing.ts
@@ -171,11 +171,26 @@ export function getModelPricing(model: string): ModelPricing {
  * Estimate token count from messages
  */
 export function estimateInputTokens(messages: ChatCompletionRequest["messages"]): number {
+  // Guard: if messages is not a non-empty array, return a conservative fallback
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return 100;
+  }
+
   let totalChars = 0;
 
   for (const msg of messages) {
     if (typeof msg.content === "string") {
       totalChars += msg.content.length;
+    } else if (Array.isArray(msg.content)) {
+      // Handle multimodal messages where content is an array of parts
+      for (const part of msg.content) {
+        if (part && typeof part === "object" && "type" in part) {
+          if (part.type === "text" && typeof (part as { type: string; text?: string }).text === "string") {
+            totalChars += (part as { type: string; text: string }).text.length;
+          }
+          // image_url parts don't contribute character count
+        }
+      }
     }
     // Add overhead for role, formatting
     totalChars += 10;


### PR DESCRIPTION
## Summary
Fixes #66 — `estimateInputTokens` crashes with `TypeError: e is not iterable` when `messages` is not an array.

**Changes:**
- Added input validation in `estimateInputTokens()` to handle `null`/`undefined`/non-array `messages` gracefully (returns conservative 100-token fallback)
- Added support for multimodal message format where `content` is an array of parts
- Added early `messages` array validation in the x402 middleware to return a clean 400 instead of a 500

## Root Cause
The x402 middleware calls `estimateChatPayment` → `estimateInputTokens` before the request handler validates the body. When a client sends `messages: null` or omits it, the `for...of` loop throws.

## Test plan
- [ ] Send POST to `/inference/openrouter/chat` with `messages: null` — expect 400
- [ ] Send POST with `messages: []` — expect normal flow
- [ ] Send POST with valid messages array — expect normal flow
- [ ] Send POST with multimodal content (array of parts) — expect correct token estimate

🤖 Generated with [Claude Code](https://claude.com/claude-code)