### PR TITLE
fix: guard estimateInputTokens crash and add CF AI fallback model

### DIFF
--- a/src/endpoints/inference/cloudflare/chat.ts
+++ b/src/endpoints/inference/cloudflare/chat.ts
@@ -283,20 +283,18 @@ export class CloudflareChat extends AIEndpoint {
       }
 
       // Record usage (model known after potential fallback)
-      c.executionCtx.waitUntil(
-        (async () => {
-          const durationMs = Date.now() - startTime;
-          recordUsage(usedModel, durationMs);
-        })()
-      );
+      const durationMs = Date.now() - startTime;
+      recordUsage(usedModel, durationMs);
 
-      return new Response(streamResponse as unknown as ReadableStream, {
-        headers: {
-          "Content-Type": "text/event-stream",
-          "Cache-Control": "no-cache",
-          Connection: "keep-alive",
-        },
-      });
+      const headers: Record<string, string> = {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      };
+      if (usedModel !== model) {
+        headers["X-Fallback-Model"] = usedModel;
+      }
+      return new Response(streamResponse as unknown as ReadableStream, { headers });
     } else {
       // Non-streaming path — attempt primary model, fall back on timeout
       let aiResponse: unknown;
@@ -359,12 +357,12 @@ export class CloudflareChat extends AIEndpoint {
 
       const result: Record<string, unknown> = {
         ok: true,
-        model: usedModel,
+        model,
         response: responseText,
         tokenType,
       };
 
-      // Surface fallback info to caller so they know which model was used
+      // Surface fallback info to caller so they know which model actually served the request
       if (usedModel !== model) {
         result.fallback_model = usedModel;
       }

--- a/src/middleware/x402.ts
+++ b/src/middleware/x402.ts
@@ -238,9 +238,9 @@ export function x402Middleware(
           return c.json({ error: "Missing or invalid 'model' field", code: "invalid_request" }, 400);
         }
 
-        // Validate messages field before calling estimateChatPayment which iterates it.
-        // Without this guard, a missing or non-array messages value causes "not iterable" in
-        // estimateInputTokens when the body is cast via `as ChatCompletionRequest`.
+        // Validate messages field before calling estimateChatPayment, which expects a non-empty
+        // array. This is request validation; downstream token estimation now guards non-array/empty
+        // values and returns a safe default instead of throwing.
         if (!Array.isArray(chatRequest.messages) || chatRequest.messages.length === 0) {
           return c.json({ error: "Missing or invalid 'messages' field: must be a non-empty array", code: "invalid_request" }, 400);
         }

--- a/src/services/pricing.ts
+++ b/src/services/pricing.ts
@@ -184,7 +184,7 @@ export function estimateInputTokens(messages: ChatCompletionRequest["messages"])
   let totalChars = 0;
 
   for (const msg of messages) {
-    if (typeof msg.content === "string") {
+    if (typeof msg?.content === "string") {
       totalChars += msg.content.length;
     } else if (Array.isArray(msg.content)) {
       // Handle multimodal messages where content is an array of parts


### PR DESCRIPTION
## Summary

- **estimateInputTokens crash fix**: Returns 100-token default when `messages` is not an array instead of throwing "e is not iterable". The x402 middleware now validates `messages` is a non-empty array before calling `estimateChatPayment`, returning 400 for invalid requests.
- **Cloudflare AI fallback model**: On timeout (error 3046), retries with `@cf/meta/llama-3.3-70b-instruct-fp8-fast` for both streaming and non-streaming paths. Successful fallback responses include a `fallback_model` field.
- **Release-please config**: Adds release-please configuration for automated versioning.

## Production Evidence

Logs from `logs.aibtc.com` (Mar 3-12, 2026) showed:
- `"e is not iterable"` crash in `estimateInputTokens` at `/inference/openrouter/chat`
- `"3046: Request timeout"` on `@cf/meta/llama-3.1-8b-instruct` with no recovery path
- Payment settlement failures cascading from relay nonce issues

## Test plan

- [x] `npm test` passes (14/14 tests)
- [x] `npm run check` (TypeScript) passes
- [ ] Send request with missing/null `messages` field — should return 400 not 500
- [ ] Trigger CF AI timeout — should fallback to llama-3.3-70b and include `fallback_model` in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)