### PR TITLE
fix: escape SQL wildcards in KV prefix queries, log parse errors

### DIFF
--- a/src/durable-objects/StorageDO.ts
+++ b/src/durable-objects/StorageDO.ts
@@ -36,7 +36,8 @@ function parseJsonField(value: unknown): Record<string, unknown> | null {
   if (!value) return null;
   try {
     return JSON.parse(value as string);
-  } catch {
+  } catch (e) {
+    console.warn('parseJsonField: failed to parse stored JSON value', e);
     return null;
   }
 }
@@ -50,7 +51,8 @@ function parseStringArray(value: unknown): string[] {
   try {
     const parsed = JSON.parse(value as string);
     return Array.isArray(parsed) ? parsed : [];
-  } catch {
+  } catch (e) {
+    console.warn('parseStringArray: failed to parse stored JSON array value', e);
     return [];
   }
 }
@@ -258,8 +260,9 @@ export class StorageDO extends DurableObject<Env> {
     const params: unknown[] = [];
 
     if (options?.prefix) {
-      query += " WHERE key LIKE ?";
-      params.push(`${options.prefix}%`);
+      query += " WHERE key LIKE ? ESCAPE '\\'";
+      const escapedPrefix = options.prefix.replace(/[%_\\]/g, '\\$&');
+      params.push(`${escapedPrefix}%`);
     }
     query += " ORDER BY key LIMIT ?";
     params.push(limit);


### PR DESCRIPTION
Fixes #72.

## Changes

### C1 — SQL wildcard injection in `kvList` (StorageDO.ts)

The `kvList` method built a `LIKE` clause directly from the user-supplied `prefix` option without escaping SQL wildcard characters. A prefix containing `%` or `_` would match unintended keys, bypassing the intended prefix boundary.

**Fix:** Escape `%`, `_`, and `\` in the prefix before appending the trailing `%`, and add `ESCAPE '\\'` to the `LIKE` clause:

```ts
query += " WHERE key LIKE ? ESCAPE '\\'";
const escapedPrefix = options.prefix.replace(/[%_\\]/g, '\\$&');
params.push(`${escapedPrefix}%`);
```

### C3 — Silent JSON parse errors in `parseJsonField` / `parseStringArray`

Both helpers swallowed parse errors with a bare `catch {}`, returning `null` or `[]` without any log output. Corrupt stored values were invisible in production logs.

**Fix:** Changed `catch` to `catch (e)` and added `console.warn(...)` before each fallback return, so errors surface in Cloudflare Worker logs.

## Testing

- `npx tsc --noEmit` — passes clean for these files (one pre-existing unrelated error in `src/services/pricing.ts` is present on `main` before this PR)
- E2E tests require a live testnet mnemonic; type check is the appropriate CI gate for this change