### PR TITLE
fix(pricing): live STX/USD price feed + ScanVerdict.scanned field

### DIFF
--- a/src/durable-objects/StorageDO.ts
+++ b/src/durable-objects/StorageDO.ts
@@ -818,6 +818,12 @@ export class StorageDO extends DurableObject<Env> {
    * Retrieve a stored scan verdict by content id.
    * Returns null if no scan has been recorded for this id.
    */
+
+  /** Derive whether a real scan was performed from the stored reason field */
+  private static scannedFromReason(reason: string): boolean {
+    const unscannedReasons = new Set(['scan_unavailable', 'scan_error', 'parse_error', 'empty_response']);
+    return !unscannedReasons.has(reason);
+  }
   async scanGet(
     id: string,
     contentType: "paste" | "kv" | "memory"
@@ -832,11 +838,13 @@ export class StorageDO extends DurableObject<Env> {
     if (result.length === 0) return null;
 
     const row = result[0];
+    const reason = row.reason as string;
     return {
       safe: (row.safe as number) === 1,
+      scanned: StorageDO.scannedFromReason(reason),
       flags: parseStringArray(row.flags),
       confidence: row.confidence as number,
-      reason: row.reason as string,
+      reason,
       contentType: row.content_type as string,
       scannedAt: row.scanned_at as string,
     };
@@ -883,6 +891,7 @@ export class StorageDO extends DurableObject<Env> {
       contentType: row.content_type as string,
       verdict: {
         safe: (row.safe as number) === 1,
+        scanned: StorageDO.scannedFromReason(row.reason as string),
         flags: parseStringArray(row.flags),
         confidence: row.confidence as number,
         reason: row.reason as string,

--- a/src/middleware/x402.ts
+++ b/src/middleware/x402.ts
@@ -34,6 +34,7 @@ import {
   validateTokenType,
   getFixedTierEstimate,
   estimateChatPayment,
+  refreshStxRate,
 } from "../services/pricing";
 import { lookupModel } from "../services/model-cache";
 import { getEndpointMetadata, buildBazaarExtension } from "../bazaar";
@@ -244,6 +245,9 @@ export function x402Middleware(
         if (!Array.isArray(chatRequest.messages) || chatRequest.messages.length === 0) {
           return c.json({ error: "Missing or invalid 'messages' field: must be a non-empty array", code: "invalid_request" }, 400);
         }
+
+        // Refresh STX price before estimation so rate reflects current market
+        await refreshStxRate(log);
 
         // Pre-payment model validation: reject unknown models before issuing 402
         if (c.env.OPENROUTER_API_KEY) {

--- a/src/services/pricing.ts
+++ b/src/services/pricing.ts
@@ -111,18 +111,56 @@ const DEFAULT_MODEL_PRICING: ModelPricing = {
 // Token Exchange Rates
 // =============================================================================
 
+/** Fallback STX/USD rate used when the live price feed is unavailable */
+const STX_FALLBACK_RATE = 0.50;
+
+/** TTL for the cached STX/USD rate (15 minutes) */
+const STX_PRICE_CACHE_TTL_MS = 15 * 60 * 1000;
+
+interface StxPriceCache {
+  rateUsd: number;
+  fetchedAt: number;
+}
+
+let stxPriceCache: StxPriceCache | null = null;
+
 /**
- * Token exchange rates (approximate, for converting USD to tokens)
- * Updated periodically based on market rates
- *
- * TODO: Replace STX rate with a dynamic price oracle (e.g., Bitflow STX/USD feed
- *       or Hiro API market data). The hardcoded rate causes pricing drift as STX
- *       market price moves. A live feed would ensure accurate USD-equivalent pricing.
+ * Fetch the live STX/USD rate from the Hiro market API and update TOKEN_RATES.
+ * Caches the result for 15 minutes. Falls back to the last cached value or
+ * STX_FALLBACK_RATE on fetch failure — never throws.
+ */
+export async function refreshStxRate(log?: Logger): Promise<void> {
+  const now = Date.now();
+  if (stxPriceCache && now - stxPriceCache.fetchedAt < STX_PRICE_CACHE_TTL_MS) {
+    return; // Cache still fresh
+  }
+
+  try {
+    const response = await fetch('https://api.hiro.so/extended/v1/market/stx/price');
+    if (!response.ok) throw new Error('HTTP ' + response.status);
+
+    const data = await response.json() as { price?: number | string };
+    const rate = typeof data.price === 'string' ? parseFloat(data.price) : Number(data.price);
+    if (!isFinite(rate) || rate <= 0) throw new Error('Invalid price value: ' + data.price);
+
+    stxPriceCache = { rateUsd: rate, fetchedAt: now };
+    TOKEN_RATES.STX = rate;
+    log?.debug?.('STX price updated', { rateUsd: rate });
+  } catch (err) {
+    const fallback = stxPriceCache?.rateUsd ?? STX_FALLBACK_RATE;
+    TOKEN_RATES.STX = fallback;
+    log?.warn?.('STX price fetch failed, using fallback rate', { error: String(err), rateUsd: fallback });
+  }
+}
+
+/**
+ * Token exchange rates (approximate, for converting USD to tokens).
+ * STX rate is kept current by refreshStxRate() — call it before pricing requests.
  */
 const TOKEN_RATES: Record<TokenType, number> = {
-  STX: 0.50,      // 1 STX ≈ $0.50 USD — hardcoded, see TODO above
-  sBTC: 100000,   // 1 sBTC ≈ $100,000 USD
-  USDCx: 1.0,     // 1 USDCx = $1 USD (Circle USDC via xReserve)
+  STX: STX_FALLBACK_RATE,   // Updated by refreshStxRate(); hardcoded fallback until first fetch
+  sBTC: 100000,              // 1 sBTC ≈ $100,000 USD
+  USDCx: 1.0,               // 1 USDCx = $1 USD (Circle USDC via xReserve)
 };
 
 // =============================================================================

--- a/src/services/safety-scan.ts
+++ b/src/services/safety-scan.ts
@@ -15,6 +15,8 @@
 export interface ScanVerdict {
   /** Whether the content is considered safe */
   safe: boolean;
+  /** Whether the scan was actually performed (false if service was unavailable) */
+  scanned: boolean;
   /** Category flags triggered (empty if safe) */
   flags: string[];
   /** Model confidence in verdict, 0.0 to 1.0 */
@@ -71,6 +73,7 @@ Rules:
  */
 const DEFAULT_VERDICT: ScanVerdict = {
   safe: true,
+  scanned: false,
   flags: [],
   confidence: 0,
   reason: "scan_unavailable",
@@ -139,6 +142,7 @@ function parseVerdict(raw: string): ScanVerdict | null {
 
   return {
     safe,
+    scanned: true,
     flags: filteredFlags,
     confidence: clampedConfidence,
     reason: obj.reason.slice(0, 200),


### PR DESCRIPTION
Fixes C2 and C4 from issue 72.

C2: Replace hardcoded STX rate (0.50 USD) with live Hiro market API fetch, 15-min cache, fallback on error.

C4: Add ScanVerdict.scanned boolean to distinguish real scans from error fallbacks.

Changes: pricing.ts (refreshStxRate), x402.ts (call refreshStxRate), safety-scan.ts (scanned field), StorageDO.ts (derive scanned from reason field).

Generated with Claude Code.