### PR TITLE
fix(x402): classify transaction_held as TRANSACTION_PENDING (closes #93)

### DIFF
--- a/src/middleware/x402.ts
+++ b/src/middleware/x402.ts
@@ -152,6 +152,13 @@ function classifyPaymentError(error: unknown, settleResult?: Partial<SettlementR
     return { code: X402_ERROR_CODES.TRANSACTION_PENDING, message: "Transaction pending in settlement relay, please retry", httpStatus: 402, retryAfter: 10 };
   }
 
+  // Relay nonce queue: transaction held due to a sender nonce gap. The relay accepted
+  // the tx but can't dispatch it until the gap is filled. Treat as retryable TRANSACTION_PENDING
+  // with a longer backoff — the gap may take 30+ seconds to resolve.
+  if (combined.includes("transaction_held") || combined.includes("transaction held")) {
+    return { code: X402_ERROR_CODES.TRANSACTION_PENDING, message: "Transaction held in relay nonce queue, please retry", httpStatus: 402, retryAfter: 30 };
+  }
+
   if (combined.includes("sender_mismatch") || combined.includes("sender mismatch")) {
     return { code: X402_ERROR_CODES.SENDER_MISMATCH, message: "Payment sender does not match expected address", httpStatus: 400 };
   }


### PR DESCRIPTION
## Problem

When the relay's `/settle` endpoint returns `errorReason: "transaction_held"` (relay accepted the tx but queued it due to a sender nonce gap), `classifyPaymentError()` doesn't match this error reason. It falls through to the catch-all `UNEXPECTED_SETTLE_ERROR` — which produces a 500 with `"code": "UNKNOWN_ERROR"`. The caller has no indication this is retryable and no idea why it failed.

## Fix

Added a `transaction_held` case to `classifyPaymentError` that maps to `TRANSACTION_PENDING` with `retryAfter: 30`:

```typescript
if (combined.includes("transaction_held") || combined.includes("transaction held")) {
  return { code: X402_ERROR_CODES.TRANSACTION_PENDING, message: "Transaction held in relay nonce queue, please retry", httpStatus: 402, retryAfter: 30 };
}
```

The 30s retryAfter is longer than `transaction_pending`'s 10s because nonce gap resolution takes more time (relay needs to fill or clear the gap before it can dispatch the held tx).

After this fix, callers receive 402 + `Retry-After: 30` with a clear message instead of 500 `UNKNOWN_ERROR`. Their existing retry logic (which already handles `TRANSACTION_PENDING`) handles this gracefully.

Closes #93