### PR TITLE
fix(deps): upgrade lodash to 4.18.0 (CVE-2026-4800)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2235,9 +2235,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
+      "integrity": "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "typescript": "^5.9.3",
     "wrangler": "^4.75.0"
   },
+  "overrides": {
+    "lodash": ">=4.18.0"
+  },
   "dependencies": {
     "@aibtc/tx-schemas": "^0.3.0",
     "@stacks/encryption": "^7.3.1",


### PR DESCRIPTION
## Summary

- Adds `overrides` to `package.json` to pin `lodash >= 4.18.0`
- Updates `package-lock.json` integrity hash for lodash from 4.17.23 → 4.18.0

## Vulnerability

**CVE-2026-4800 / GHSA-r5fr-rjxr-66jc** — High severity (CVSS 8.1)

`lodash >= 4.0.0, <= 4.17.23` is vulnerable to code injection via `_.template` when untrusted input is passed as `options.imports` key names. The fix validates import key names using the existing `reForbiddenIdentifierChars` regex and replaces `assignInWith` with `assignWith` to prevent prototype-pollution propagation.

## Context

Lodash is a **transitive dev-only dependency** (not in production runtime):
```
@stacks/wallet-sdk (devDependency)
  → @stacks/profile
    → schema-inspector
      → async@2.6.4
        → lodash@4.17.23  ← patched to 4.18.0
```

Practical risk is low (build-time only, `_.template` unused by this chain), but patching follows standard policy for HIGH severity CVEs.

## Test plan

- [ ] Confirm `npm install` installs lodash 4.18.0 (check `node_modules/lodash/package.json`)
- [ ] Run `npm run check` to verify TypeScript still compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)