### PR TITLE
fix(deps): upgrade axios to 1.15.0 to patch CVE-2025-62718 (SSRF)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@stacks/encryption": "^7.3.1",
         "@stacks/network": "^7.3.1",
         "@stacks/transactions": "^7.3.1",
+        "axios": "^1.15.0",
         "chanfana": "^3.0.0",
         "hono": "^4.12.12",
         "x402-stacks": "^2.0.1"
@@ -1440,14 +1441,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/base-x": {
@@ -2446,10 +2447,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/ripemd160-min": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@stacks/encryption": "^7.3.1",
     "@stacks/network": "^7.3.1",
     "@stacks/transactions": "^7.3.1",
+    "axios": "^1.15.0",
     "chanfana": "^3.0.0",
     "hono": "^4.12.12",
     "x402-stacks": "^2.0.1"


### PR DESCRIPTION
## Summary

- Upgrades axios from 1.13.5 → 1.15.0 to patch **CVE-2025-62718** (GHSA-3p68-rc4w-qgx5, CVSS 9.3)
- Pins axios as a direct dependency to override the transitive version from `x402-stacks`
- Vulnerability: NO_PROXY hostname normalization bypass allows SSRF via `localhost.` (trailing dot) or `[::1]` (IPv6 literal) addresses

## Vulnerability Details

**CVE-2025-62718** — Axios has a NO_PROXY Hostname Normalization Bypass leading to SSRF

Axios did not normalize hostnames before checking `NO_PROXY` rules. Requests to `localhost.` (trailing dot) or `[::1]` would bypass NO_PROXY matching and route through the proxy — allowing attackers to force traffic through an attacker-controlled proxy and bypass SSRF protections.

**Impact**: Applications using `NO_PROXY=localhost,127.0.0.1,::1` to protect loopback/internal access are vulnerable. CVSS 9.3 (CVSS:4.0 AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:L/VA:L/SC:H/SI:L/SA:L).

**Fix**: axios 1.15.0 normalizes hostnames before NO_PROXY evaluation.

## Test plan

- [ ] CI passes with updated lock file
- [ ] Dependabot alert #22 resolves after merge

Fixes: https://github.com/aibtcdev/x402-api/security/dependabot/22

🤖 Generated with [Claude Code](https://claude.com/claude-code)