### PR TITLE
fix: retry settlement on conflicting_nonce with exponential backoff

### DIFF
--- a/src/middleware/x402.ts
+++ b/src/middleware/x402.ts
@@ -504,51 +504,81 @@ export function x402Middleware(
       network: networkV2,
     });
 
+    // Exponential backoff retry for conflicting_nonce errors.
+    // When two concurrent settlements race on the relay, one may be rejected with
+    // conflicting_nonce. This is a transient relay-side condition — retrying with
+    // backoff gives the relay time to clear the nonce contention. See issue #84.
+    const CONFLICTING_NONCE_MAX_RETRIES = 3;
+    const CONFLICTING_NONCE_BACKOFF_MS = [5_000, 10_000, 20_000];
+
     let settleResult: SettlementResponseV2;
-    try {
-      settleResult = await verifier.settle(paymentPayload, {
-        paymentRequirements,
-      });
+    let settleAttempt = 0;
+    while (true) {
+      try {
+        settleResult = await verifier.settle(paymentPayload, {
+          paymentRequirements,
+        });
 
-      log.debug("Settle result", { ...settleResult });
-    } catch (error) {
-      const errorStr = String(error);
-      log.error("Payment settlement exception", { error: errorStr });
+        log.debug("Settle result", { ...settleResult });
 
-      const classified = classifyPaymentError(error);
-      logPaymentEvent(log, classified.httpStatus >= 500 ? "error" : "warn", "payment.retry_decision", {
-        route: c.req.path,
-        status: "failed",
-        action: getRetryAction(classified.code),
-      }, {
-        classification_code: classified.code,
-        http_status: classified.httpStatus,
-        retry_after: classified.retryAfter ?? null,
-        instability: derivePaymentInstability({
-          classifiedCode: classified.code,
-          error: errorStr,
-        }),
-        relay_failure: true,
-        exceptionMessage: errorStr,
-      });
-      if (classified.retryAfter) {
-        c.header("Retry-After", String(classified.retryAfter));
-      }
+        // If we got a conflicting_nonce failure and still have retries left, retry.
+        if (
+          !settleResult.success &&
+          settleResult.errorReason === "conflicting_nonce" &&
+          settleAttempt < CONFLICTING_NONCE_MAX_RETRIES
+        ) {
+          const delayMs = CONFLICTING_NONCE_BACKOFF_MS[settleAttempt] ?? 20_000;
+          log.warn("Conflicting nonce on settlement, retrying with backoff", {
+            attempt: settleAttempt + 1,
+            maxRetries: CONFLICTING_NONCE_MAX_RETRIES,
+            delayMs,
+          });
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+          settleAttempt++;
+          continue;
+        }
 
-      return c.json(
-        {
-          error: classified.message,
-          code: classified.code,
-          asset,
-          network: networkV2,
-          resource: c.req.path,
-          details: {
-            exceptionMessage: errorStr,
+        // Success or a non-retryable failure — exit the loop.
+        break;
+      } catch (error) {
+        const errorStr = String(error);
+        log.error("Payment settlement exception", { error: errorStr });
+
+        const classified = classifyPaymentError(error);
+        logPaymentEvent(log, classified.httpStatus >= 500 ? "error" : "warn", "payment.retry_decision", {
+          route: c.req.path,
+          status: "failed",
+          action: getRetryAction(classified.code),
+        }, {
+          classification_code: classified.code,
+          http_status: classified.httpStatus,
+          retry_after: classified.retryAfter ?? null,
+          instability: derivePaymentInstability({
+            classifiedCode: classified.code,
+            error: errorStr,
+          }),
+          relay_failure: true,
+          exceptionMessage: errorStr,
+        });
+        if (classified.retryAfter) {
+          c.header("Retry-After", String(classified.retryAfter));
+        }
+
+        return c.json(
+          {
+            error: classified.message,
+            code: classified.code,
+            asset,
+            network: networkV2,
+            resource: c.req.path,
+            details: {
+              exceptionMessage: errorStr,
+            },
           },
-        },
-        classified.httpStatus as 400 | 402 | 500 | 502 | 503
-      );
-    }
+          classified.httpStatus as 400 | 402 | 500 | 502 | 503
+        );
+      }
+    } // end while (retry loop)
 
     if (!settleResult.success) {
       log.error("Payment settlement failed", { ...settleResult });


### PR DESCRIPTION
## Summary

Fixes #84 — concurrent x402 payment settlements can hit nonce contention at the relay, causing both to fail with `conflicting_nonce`. This is a transient relay-side race condition (not a client error), so the middleware should retry transparently before propagating the failure to the caller.

## Changes

- Wrapped `verifier.settle()` in a `while` retry loop in `src/middleware/x402.ts`
- On `conflicting_nonce` in `settleResult.errorReason`, retry up to **3 times** with exponential backoff: **5s → 10s → 20s**
- All other errors (non-`conflicting_nonce` failures, thrown exceptions) fall through immediately — no change to existing behavior
- Added a `log.warn` on each retry attempt for observability

## Why this approach

The issue logs show the relay itself returns `conflicting_nonce` when two settlements land within the same second. The relay nonce contention clears quickly, so a short delay (5s first retry) recovers most concurrent cases without the client needing to rebuild the payment.

## Testing

No new tests are added (E2E tests require a live relay). The fix is isolated to the retry wrapper around the existing `settle()` call. All pre-existing TypeScript errors in `src/endpoints/hashing/` are unrelated and pre-date this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)