### PR TITLE
chore(deps): bump @aibtc/tx-schemas to ^1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.2",
       "hasInstallScript": true,
       "dependencies": {
-        "@aibtc/tx-schemas": "^1.0.0",
+        "@aibtc/tx-schemas": "^1.1.0",
         "@stacks/encryption": "^7.3.1",
         "@stacks/network": "^7.3.1",
         "@stacks/transactions": "^7.3.1",
@@ -28,9 +28,9 @@
       }
     },
     "node_modules/@aibtc/tx-schemas": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aibtc/tx-schemas/-/tx-schemas-1.0.0.tgz",
-      "integrity": "sha512-KFVfzP+1gLU67mHL94ck4ue1QDJIMjlHwaOya58q2cGPwuSjGjixx/Rt/AsWJr+ppRWECZgUm9Pv+N8kfL3r5w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aibtc/tx-schemas/-/tx-schemas-1.1.0.tgz",
+      "integrity": "sha512-jCautY4s8xT6oYC6l5d5tR9pbKTIziyny3YFI77mcmkoCzZzw7oedARYARuw1DSyxcHpXVoRTL0VM6MlTYA3LQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lodash": ">=4.18.0"
   },
   "dependencies": {
-    "@aibtc/tx-schemas": "^1.0.0",
+    "@aibtc/tx-schemas": "^1.1.0",
     "@stacks/encryption": "^7.3.1",
     "@stacks/network": "^7.3.1",
     "@stacks/transactions": "^7.3.1",


### PR DESCRIPTION
## Summary

Bumps `@aibtc/tx-schemas` from `^1.0.0` to `^1.1.0`. Aligns x402-api with the canonical version used by `x402-sponsor-relay`, `agent-news`, and `landing-page`.

## Why now

Part of Wave 2 sprint Theme 2 — tx-schemas standardization. The audit (see Wave 2 batch C2) found:
- relay/agent-news/landing-page already on `^1.1.0` ✅
- x402-api on `^1.0.0` (this PR)
- mcp-server on `^0.7.0` (deferred — crosses 1.0 breaking change)
- skills on `^0.3.0` (deferred — crosses 1.0 breaking change)

This bump is safe: 1.0 → 1.1 is a semver minor with no breaking changes per upstream CHANGELOG.

## Test plan

- [x] `npm install` resolves `node_modules/@aibtc/tx-schemas@1.1.0`
- [x] No code-side breakage (semver minor)
- [x] Lockfile regenerated; only `package.json` + `package-lock.json` touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)