### PR TITLE
fix(ax-discovery): bind agent card URLs to request origin (closes #113)

### DIFF
--- a/src/endpoints/ax-discovery.ts
+++ b/src/endpoints/ax-discovery.ts
@@ -1500,34 +1500,38 @@ const TOPIC_DOCS: Record<string, string> = {
   "payment-flow": PAYMENT_FLOW_DOC,
 };
 
-// Agent card
-const AGENT_CARD = {
+// Agent card builder. URLs are bound to the request origin so the same code
+// deployed to x402.aibtc.com and x402.aibtc.dev returns network-appropriate
+// discovery pointers — testnet agents discover testnet endpoints, not mainnet.
+function buildAgentCard(requestUrl: string) {
+  const base = new URL(requestUrl).origin;
+  return {
   name: "x402 Stacks API",
   description:
     "Pay-per-use API powered by x402 v2 protocol on Stacks blockchain. " +
     "Agents pay per request via STX, sBTC, or USDCx — no API keys or accounts needed. " +
     "Provides inference (LLM), hashing, Stacks utilities, and agent storage.",
-  url: "https://x402.aibtc.com",
+  url: base,
   provider: {
     organization: "AIBTC Working Group",
     url: "https://aibtc.com",
   },
   // x402 protocol version (not the package version, which is in package.json)
   version: "2.0.0",
-  documentationUrl: "https://x402.aibtc.com/llms.txt",
-  openApiUrl: "https://x402.aibtc.com/openapi.json",
+  documentationUrl: `${base}/llms.txt`,
+  openApiUrl: `${base}/openapi.json`,
   documentation: {
-    quickStart: "https://x402.aibtc.com/llms.txt",
-    fullReference: "https://x402.aibtc.com/llms-full.txt",
-    openApiSpec: "https://x402.aibtc.com/openapi.json",
-    x402Manifest: "https://x402.aibtc.com/x402.json",
+    quickStart: `${base}/llms.txt`,
+    fullReference: `${base}/llms-full.txt`,
+    openApiSpec: `${base}/openapi.json`,
+    x402Manifest: `${base}/x402.json`,
     platform: "https://aibtc.com/llms.txt",
     topicDocs: {
-      index: "https://x402.aibtc.com/topics",
-      inference: "https://x402.aibtc.com/topics/inference",
-      hashing: "https://x402.aibtc.com/topics/hashing",
-      storage: "https://x402.aibtc.com/topics/storage",
-      paymentFlow: "https://x402.aibtc.com/topics/payment-flow",
+      index: `${base}/topics`,
+      inference: `${base}/topics/inference`,
+      hashing: `${base}/topics/hashing`,
+      storage: `${base}/topics/storage`,
+      paymentFlow: `${base}/topics/payment-flow`,
     },
   },
   capabilities: {
@@ -1746,7 +1750,8 @@ const AGENT_CARD = {
       outputModes: ["application/json"],
     },
   ],
-};
+  } as const;
+}
 
 // =============================================================================
 // AX Discovery Router
@@ -1836,7 +1841,7 @@ axDiscoveryRouter.get("/topics/:topic", (c) => {
 });
 
 axDiscoveryRouter.get("/.well-known/agent.json", (c) => {
-  return c.json(AGENT_CARD, 200, {
+  return c.json(buildAgentCard(c.req.url), 200, {
     "Cache-Control": "public, max-age=3600, s-maxage=86400",
   });
 });


### PR DESCRIPTION
## Summary

Closes #113 (RPC-binding audit Finding 1).

`AGENT_CARD` was a static const with `https://x402.aibtc.com` hardcoded across 9 fields (`url`, `documentationUrl`, `openApiUrl`, `x402Manifest`, `topicDocs.{index,inference,hashing,storage,paymentFlow}`). The same code runs on mainnet (`x402.aibtc.com`) and testnet (`x402.aibtc.dev`), so testnet agents fetching `/.well-known/agent.json` received a card pointing entirely at mainnet.

## Fix

Convert `AGENT_CARD` const to `buildAgentCard(requestUrl)`. Derives `base` from `new URL(requestUrl).origin`, then templates all 9 fields. Handler at `axDiscoveryRouter.get("/.well-known/agent.json", ...)` invokes the builder with `c.req.url` per request.

## Why use `c.req.url` instead of `env.X402_NETWORK`

- **Auto-bind**: works correctly on any preview/dev URL the worker happens to be served on (e.g., `*.workers.dev`), without env-flag plumbing.
- **Source of truth**: the agent that fetched this card just talked to *that origin*, so returning that origin in `url` is by definition correct.
- **No drift**: env value can be set wrong (testnet env on mainnet domain or vice versa); origin can't.

## Out of scope (deferred)

The `llms.txt` / `llms-full.txt` / topic doc text bodies still contain `x402.aibtc.com` example URLs (lines 30-355 of the same file, ~80 occurrences). Those are user-facing documentation examples, not auth-relevant discovery URLs, so the leak vector is much lower. Could be done in a follow-up by parameterizing the doc strings (likely needs string-template refactor — bigger change). Filing as follow-up if needed.

## Test plan

- [x] `npm run check` passes (TypeScript)
- [ ] When merged: `curl https://x402.aibtc.dev/.well-known/agent.json | jq .url` returns `"https://x402.aibtc.dev"` (currently returns `"https://x402.aibtc.com"`)
- [ ] `curl https://x402.aibtc.com/.well-known/agent.json | jq .url` continues to return `"https://x402.aibtc.com"` (unchanged on mainnet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)