### PR TITLE
fix(payment-middleware): fail closed when X402_SERVER_ADDRESS missing outside dev (closes #112)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -302,10 +302,20 @@ app.use("*", async (c, next) => {
     return next();
   }
 
-  // Skip if no x402 config (local dev without payment setup)
+  // Skip is allowed only in local development — staging/production deploys must
+  // have X402_SERVER_ADDRESS or all paid routes silently become free.
   if (!c.env.X402_SERVER_ADDRESS) {
-    c.var.logger.warn("X402_SERVER_ADDRESS not configured, skipping payment verification");
-    return next();
+    if (c.env.ENVIRONMENT === "development") {
+      c.var.logger.warn("X402_SERVER_ADDRESS not configured (local dev), skipping payment verification");
+      return next();
+    }
+    c.var.logger.error("X402_SERVER_ADDRESS not configured outside local dev — refusing request", {
+      environment: c.env.ENVIRONMENT,
+    });
+    return c.json(
+      { error: "x402 misconfiguration", code: "NOT_CONFIGURED" },
+      503
+    );
   }
 
   // Get tier from endpoint config

--- a/src/middleware/x402.ts
+++ b/src/middleware/x402.ts
@@ -288,10 +288,21 @@ export function x402Middleware(
   return async (c, next) => {
     const log = c.var.logger;
 
-    // Check if x402 is configured
+    // Check if x402 is configured. Skip is allowed only in local development —
+    // staging/production deploys must have X402_SERVER_ADDRESS or all paid routes
+    // silently become free.
     if (!c.env.X402_SERVER_ADDRESS) {
-      log.warn("X402_SERVER_ADDRESS not configured, skipping payment verification");
-      return next();
+      if (c.env.ENVIRONMENT === "development") {
+        log.warn("X402_SERVER_ADDRESS not configured (local dev), skipping payment verification");
+        return next();
+      }
+      log.error("X402_SERVER_ADDRESS not configured outside local dev — refusing request", {
+        environment: c.env.ENVIRONMENT,
+      });
+      return c.json(
+        { error: "x402 misconfiguration", code: "NOT_CONFIGURED" },
+        503
+      );
     }
 
     // Get token type from header or query


### PR DESCRIPTION
## Summary

Closes #112 (fail-open audit findings).

Two payment middleware sites silently skipped payment verification when `X402_SERVER_ADDRESS` was missing, intended as a local-dev convenience but failing open in any environment:

- `src/middleware/x402.ts:292` (per-route x402 middleware)
- `src/index.ts:305` (global request middleware)

If `X402_SERVER_ADDRESS` were ever unset in staging or production (bad deploy, secret rotation glitch, env-var migration, env-var name typo), every paid endpoint would silently become free with only a `warn` log.

## Fix (Option A from the audit)

Restrict the skip to `ENVIRONMENT === \"development\"`. In staging and production:
- Log at `error` level (not `warn`)
- Return HTTP 503 with `{ error: \"x402 misconfiguration\", code: \"NOT_CONFIGURED\" }`

`ENVIRONMENT` is already plumbed through wrangler.jsonc per env (`development` / `staging` / `production`).

## Why ENVIRONMENT and not X402_NETWORK

`X402_NETWORK` is typed strictly as `\"mainnet\" | \"testnet\"` in `src/types.ts:53` — using a `\"local\"` literal would require widening that type. `ENVIRONMENT` is already declared as `string` (line 50) and already takes the `development` value in local dev (`wrangler.jsonc:35`). Cleaner.

## Test plan

- [x] `npm run check` passes
- [ ] Local dev (`ENVIRONMENT=development`, no X402_SERVER_ADDRESS) — skip behavior preserved
- [ ] Staging without X402_SERVER_ADDRESS — returns 503 + error log instead of free responses
- [ ] Production with X402_SERVER_ADDRESS set — unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)