### PR TITLE
fix(deps): pin tmp to >=0.2.6 to patch CVE-2026-44705

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,9 @@
         "patch-package": "^8.0.1",
         "typescript": "^5.9.3",
         "wrangler": "^4.75.0"
+      },
+      "overrides": {
+        "tmp": ">=0.2.6"
       }
     },
     "node_modules/@aibtc/tx-schemas": {
@@ -2616,9 +2619,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "wrangler": "^4.75.0"
   },
   "overrides": {
-    "lodash": ">=4.18.0"
+    "lodash": ">=4.18.0",
+    "tmp": ">=0.2.6"
   },
   "dependencies": {
     "@aibtc/tx-schemas": "^1.1.0",


### PR DESCRIPTION
## Summary

- `tmp` (transitive dep via `patch-package`) had a path traversal vulnerability (CVE-2026-44705) in versions <0.2.6
- Added `"tmp": ">=0.2.6"` to the `overrides` section in package.json and updated package-lock.json to resolve to 0.2.6
- The vulnerability allows path traversal via unsanitized `prefix`/`postfix`/`dir` options — low direct exposure since `tmp` is only used by the dev-time `patch-package` tool, not in production Cloudflare Worker code

## Test plan

- [ ] Verify `node_modules/tmp` resolves to 0.2.6 after `npm install`
- [ ] Confirm Dependabot alert #41 closes after merge

Closes https://github.com/aibtcdev/x402-api/security/dependabot/41

🤖 Generated with [Claude Code](https://claude.com/claude-code)