### PR TITLE
fix(deps): bump js-yaml to 4.3.0 (CVE-2026-59869)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1721,6 +1721,28 @@
         "zod": "^4.0.0"
       }
     },
+    "node_modules/chanfana/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -2232,18 +2254,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/json-stable-stringify": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "overrides": {
     "lodash": ">=4.18.0",
-    "sharp": ">=0.35.2"
+    "sharp": ">=0.35.2",
+    "js-yaml": ">=4.3.0 <5.0.0"
   },
   "dependencies": {
     "@aibtc/tx-schemas": "^1.1.0",


### PR DESCRIPTION
## Summary
- js-yaml <4.3.0 (pulled in transitively via `chanfana@3.0.0`) is vulnerable to quadratic CPU consumption via YAML merge-key chains ([GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m))
- Pinned via a `package.json` override (`"js-yaml": ">=4.3.0 <5.0.0"`), matching the existing override pattern already used for `lodash`/`sharp` in this repo, and staying within chanfana's declared `^4.1.0` range
- Regenerated `package-lock.json` with npm; only `js-yaml` (now nested under `chanfana`) changed

Fixes dependabot alert #86.

## Test plan
- [x] `package.json`/`package-lock.json` validated as well-formed JSON
- [x] Confirmed only js-yaml 4.1.1 → 4.3.0 changed (same major version, no other packages touched)
- [ ] CI / CF Workers Builds run on this PR