### PR TITLE
fix(deps): override ws to >=8.21.0 (CVE-2026-48779)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2890,9 +2890,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "overrides": {
     "lodash": ">=4.18.0",
-    "sharp": ">=0.35.2"
+    "sharp": ">=0.35.2",
+    "ws": ">=8.21.0"
   },
   "dependencies": {
     "@aibtc/tx-schemas": "^1.1.0",


### PR DESCRIPTION
## Summary
- Dependabot alert #73 (high, CVE-2026-48779): `ws` 8.18.0 is a transitive dev dependency pulled in by `miniflare` (via `wrangler`), vulnerable in range `>=8.0.0 <8.21.0`.
- Adds an npm `overrides` entry pinning `ws` to `>=8.21.0` and regenerates the lockfile (`ws` now resolves to 8.21.1).
- Does **not** bump `wrangler` itself — the pending major wrangler bump (dependabot PRs #141/#142/#143) is separately failing Cloudflare Workers Builds in the cloud build env only. Keeping this fix independent avoids blocking on that.
- `ws` here is dev-only (miniflare's local dev server), not part of the deployed Worker bundle, so exposure is limited to local `wrangler dev` usage — still worth patching since dependabot flags it as reachable from a manifest.

## Test plan
- [x] `npm install --package-lock-only --ignore-scripts` regenerates `package-lock.json` cleanly, only touching the `ws` entry
- [ ] CI green
- [ ] Confirm dependabot alert #73 auto-closes once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)